### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language: python
+python:
+- '2.7'
+- '3.5'
+addons:
+  apt:
+    packages:
+    - protobuf-compiler
+    - protobuf-c-compiler
+    - python-protobuf
+install:
+- pip install -r requirements.txt
+- pip install pep8
+script:
+- pep8 --ignore=E501,E731 .
+notifications:
+  slack:
+    secure: OVA5zqmalbyJb0H5+zeLJpcxf6Vx7lDunn/PcZHRKnSACFgygSgY4Hq0Nc97E4noIj2COQFEMO8qmpIQ5U2vxZ1hovguM/xZ5q0fdPdRM47ID3q3GIyuPxy+7rAEES5vrID9fswfKV2N60BRy98PeTzexNST6wMTDIJdTRapmnFKqt9ketE3n4bbjGvUm6NZiQ06V6SPuA0BWzabmCuAwfh655ve37SclFABagjZ0oWqUsYtwElcrXM2fnyz/u3pkLKzMUQ5RRheXUpdZOxMvJ8nQnckh4hyDPEbPEt1VFblERUJPBd2WSNhmmvMLgbbCvDHIBaGW0Dqf0c7/DopWFReIxYMOCau8jycbMN5Xx4xZ6DA8KSXOOi9kNIPTtn5AbOOE6t3wugTcCKI7kX/O1FMUHxvhXNxI+fGBQSwIw5csu/SL8ZlHv1EFIVhVI1eFpuCAudQYGEuPv6jvBLBtRb+5zu2VTJ8qADqPGAp6VqXoZ9XHOWBwrhAR/F14Jk6cDCHAoHC/sUbns9AmUnQOz19ugtoEq7NQkB53fENbC+DN+IO9YyCwnCV9rqQLlxt4qN9cQ985yzh7O4T5csd3Utc0wqtvn7100SY3sbhu2I842aYp8qqYF4UrTl6oCL3Z14aIfKLeI/MTknbdqF8uZGwBsHpjZtAzgO3EsCNDbU=


### PR DESCRIPTION
Tests under Python 2.7 and 3.5 (can be changed if we choose to only support one or the other).

Ignores E501 (max line length) and E731 (binding a lambda expression to a variable)

Fixes #4 
