### PR TITLE
Add slack bouncer to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,12 @@ We want you to contribute!
 
 Any and all contributions are appreciated, even if your change does not get accepted.
 
+Contributors are encouraged to join our Slack team to discuss development. Just click [here](https://openpogo-slack.herokuapp.com/) and sign up using your email.
 
-## Getting Started
-Coming soon
+Please do not join the Slack team to ask questions that are not related to development. Instead, submit these questions as [GitHub Issues](https://github.com/OpenPoGo/OpenPoGoBot/issues).
+
+
+
 
 ## Pull Requests
   - Please squash your commits before merging.


### PR DESCRIPTION
Short Description: 
Add link for slack bouncer and info on who should use slack.

@OpenPoGo/maintainers
