### PR TITLE
Fix #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ pip install -r requirements.txt
       -ms MAX_STEP, --max-steps MAX_STEP            Set the steps around your initial location (DEFAULT 5 mean 25 cells around your location)
       -cp COMBAT_POWER, --combat-power COMBAT_POWER Transfer Pokemon that have CP less than this value (default 100)",
       -iv IV, --pokemon-potential IV                Set the ratio for the IV values to transfer (DEFAULT 0.4 eg. 0.4 will transfer a pokemon with IV 0.3)
-      -if LIST, --item-filter LIST                  Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected)" 
+      -ri, --recycle-items                          Recycle unneeded items automatically
+      -if LIST, --item-filter LIST                  Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected). Requires --recycle-items. 
       -d, --debug                                   Debug Mode
       -t, --test                                    Only parse the specified location
-      -if ITEM_FILTER, --item-filter ITEM_FILTER    Filter items to recycle in the form of "id,id,id    "
 
 ### Command Line Example
     Pokemon Trainer Club (PTC) account:

--- a/pokecli.py
+++ b/pokecli.py
@@ -52,7 +52,8 @@ def init_config():
         "pokemon_potential": 0.40,
         "max_steps": 50,
         "distance_unit": "km",
-        "ign_init_trans": ""
+        "ign_init_trans": "",
+        "recycle_items": False
     }
 
     parser = argparse.ArgumentParser()
@@ -115,6 +116,12 @@ def init_config():
         help="Transfer all pokemon with same ID on bot start, except pokemon with highest CP. Respects --cp",
         action="store_true",
         dest="initial_transfer")
+    parser.add_argument(
+        "-ri",
+        "--recycle-items",
+        help="Recycle unneeded items automatically",
+        action="store_true",
+        dest="recycle_items")
     parser.add_argument("-d",
                         "--debug",
                         help="Debug Mode",


### PR DESCRIPTION
### Short Description:

Fix #76 by setting default option and adding command line parameter.
### Changes:
- Sets `recycle_items` to False by default.
- Adds `-ri, --recycle-items` command line parameter.
- Fixes #76.

@OpenPoGo/maintainers
