### PR TITLE
Check if recycle_items is defined

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -174,6 +174,8 @@ def init_config():
         config.username = input("Username: ")
     if config.password is None:
         config.password = getpass("Password: ")
+    if config.__dict__.get("recycle_items") is None:
+        config.recycle_items = {}
 
     return config
 


### PR DESCRIPTION
### Short Description:

checks if `recycle_items` is defined, and inits it as an empty object if it is not.

@OpenPoGo/maintainers

fixes #76
