### PR TITLE
Add exclude plugins option, item recycling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ pip install -r requirements.txt
       -w SPEED,  --walk SPEED                       Walk instead of teleport with given speed (meters per second max 4.16 because of walking end on 15km/h)
       -du UNIT, --distance-unit UNIT                Set the unit to display distance in (e.g, km for kilometers, mi for miles, ft for feet)
       -it, --initial-transfer                       Start the bot with a pokemon clean up, keeping only the higher CP of each pokemon. It respects -c as upper limit to release.
+      -ig LIST, --ign-init-trans LIST               Pass a list of pokemon to ignore during initial transfer (e.g. 017,049,001)
       -ms MAX_STEP, --max-steps MAX_STEP            Set the steps around your initial location (DEFAULT 5 mean 25 cells around your location)
       -cp COMBAT_POWER, --combat-power COMBAT_POWER Transfer Pokemon that have CP less than this value (default 100)",
       -iv IV, --pokemon-potential IV                Set the ratio for the IV values to transfer (DEFAULT 0.4 eg. 0.4 will transfer a pokemon with IV 0.3)
-      -if LIST, --item-filter LIST                  Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected)"
-      -ig LIST, --ign-init-trans LIST               Pass a list of pokemon to ignore during initial transfer (e.g. 017,049,001)
+      -ri, --recycle-items                          Recycle unneeded items automatically
+      -if LIST, --item-filter LIST                  Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected). Requires --recycle-items. 
+      -ep LIST, --exclude-plugins LIST              Pass a list of plugins to exclude from the loading process (e.g, \"logger,web\").
       -k KEY, --gmapkey KEY                         Set a google maps API key to use
       -d, --debug                                   Debug Mode
       -t, --test                                    Only parse the specified location

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install -r requirements.txt
       -iv IV, --pokemon-potential IV                Set the ratio for the IV values to transfer (DEFAULT 0.4 eg. 0.4 will transfer a pokemon with IV 0.3)
       -ri, --recycle-items                          Recycle unneeded items automatically
       -if LIST, --item-filter LIST                  Pass a list of unwanted items to recycle when collected at a Pokestop (e.g, [\"101\",\"102\",\"103\",\"104\"] to recycle potions when collected). Requires --recycle-items. 
-      -ep LIST, --exclude-plugins LIST              Pass a list of plugins to exclude from the loading process (e.g, \"logger,web\").
+      -ep LIST, --exclude-plugins LIST              Pass a list of plugins to exclude from the loading process (e.g, logger,web).
       -k KEY, --gmapkey KEY                         Set a google maps API key to use
       -d, --debug                                   Debug Mode
       -t, --test                                    Only parse the specified location

--- a/pokecli.py
+++ b/pokecli.py
@@ -52,7 +52,9 @@ def init_config():
         "pokemon_potential": 0.40,
         "max_steps": 50,
         "distance_unit": "km",
-        "ign_init_trans": ""
+        "ign_init_trans": "",
+        "exclude_plugins": "",
+        "recycle_items": False
     }
 
     parser = argparse.ArgumentParser()
@@ -97,12 +99,6 @@ def init_config():
         type=str,
         dest="distance_unit")
     parser.add_argument(
-        "-it",
-        "--initial-transfer",
-        help="Start the bot with a pokemon clean up, keeping only the higher CP of each pokemon. It respects -c as upper limit to release.",
-        action="store_true",
-        dest="initial_transfer")
-    parser.add_argument(
         "-ms",
         "--max-steps",
         help="Set the steps around your initial location (DEFAULT 5 mean 25 cells around your location)",
@@ -115,6 +111,18 @@ def init_config():
         help="Transfer Pokemon that have CP less than this value (default 100)",
         type=int,
         dest="cp")
+    parser.add_argument(
+        "-it",
+        "--initial-transfer",
+        help="Transfer all pokemon with same ID on bot start, except pokemon with highest CP. Respects --cp",
+        action="store_true",
+        dest="initial_transfer")
+    parser.add_argument(
+        "-ri",
+        "--recycle-items",
+        help="Recycle unneeded items automatically",
+        action="store_true",
+        dest="recycle_items")
     parser.add_argument(
         "-iv",
         "--pokemon-potential",
@@ -152,6 +160,13 @@ def init_config():
         action="store_true",
         dest="test")
 
+    parser.add_argument(
+        "-ep",
+        "--exclude-plugins",
+        help="Pass a list of plugins to exclude from the loading process (e.g, \"logger,web\").",
+        type=str,
+        dest="exclude_plugins")
+
     config = parser.parse_args()
 
     if config.json:
@@ -173,6 +188,8 @@ def init_config():
     for key in config.__dict__:
         if config.__dict__.get(key) is None and default_config.get(key) is not None:
             config.__dict__[key] = default_config.get(key)
+
+    config.exclude_plugins = [plugin_name for plugin_name in config.exclude_plugins.split(",")]
 
     print(config.__dict__)
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -163,7 +163,7 @@ def init_config():
     parser.add_argument(
         "-ep",
         "--exclude-plugins",
-        help="Pass a list of plugins to exclude from the loading process (e.g, \"logger,web\").",
+        help="Pass a list of plugins to exclude from the loading process (e.g, logger,web).",
         type=str,
         dest="exclude_plugins")
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -45,7 +45,10 @@ class PokemonGoBot(object):
 
         # load all plugin modules
         for plugin in self.plugin_manager.get_available_plugins():
-            self.plugin_manager.load_plugin(plugin)
+            if plugin not in self.config.exclude_plugins:
+                self.plugin_manager.load_plugin(plugin)
+            else:
+                logger.log("Not loading plugin \"{}\"".format(plugin))
 
     def start(self):
         self._setup_logging()


### PR DESCRIPTION
### Short Description:

Adds the ability to exclude plugins as well as the ability to toggle item recycling. Closes #76 and #78.
### Changes:
- Adds the `-ep, --exclude-plugins` command line option
- Adds the `-ri, --recycle-items` command line option
- Update README.md to reflect the new options.
- Update git submodule because I broke it by accident

@OpenPoGo/maintainers
