### PR TITLE
Fix some stuff broken in the Python 2 to 3 transition

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -14,7 +14,7 @@ import googlemaps
 from pokemongo_bot import logger, cell_workers, human_behaviour, item_list, stepper
 from pokemongo_bot.event_manager import manager
 from pokemongo_bot.cell_workers import PokemonCatchWorker, SeenFortWorker, InitialTransferWorker, WalkTowardsFortWorker, RecycleItemsWorker
-from pokemongo_bot.cell_workers.utils import filtered_forts, distance, convert_to_utf8
+from pokemongo_bot.utils import filtered_forts, distance, convert_to_utf8
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.item_list import Item
 from pokemongo_bot.stepper import Stepper

--- a/pokemongo_bot/cell_workers/seen_fort_worker.py
+++ b/pokemongo_bot/cell_workers/seen_fort_worker.py
@@ -5,7 +5,7 @@ import time
 from pgoapi.utilities import f2i
 from pokemongo_bot import logger
 from pokemongo_bot.human_behaviour import sleep
-from pokemongo_bot.cell_workers.utils import format_time
+from pokemongo_bot.utils import format_time
 from pokemongo_bot.cell_workers.recycle_items_worker import RecycleItemsWorker
 
 

--- a/pokemongo_bot/cell_workers/walk_towards_fort_worker.py
+++ b/pokemongo_bot/cell_workers/walk_towards_fort_worker.py
@@ -2,7 +2,7 @@
 
 from pokemongo_bot import logger
 from pokemongo_bot.human_behaviour import sleep
-from pokemongo_bot.cell_workers.utils import distance, format_dist
+from pokemongo_bot.utils import distance, format_dist
 
 class WalkTowardsFortWorker(object):
 

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 import time
 
-from pokemongo_bot.cell_workers.utils import convert_to_utf8
 from pokemongo_bot.event_manager import manager
+from pokemongo_bot.utils import convert_to_utf8
+
 try:
     #pylint: disable=import-error
     import lcd

--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -6,7 +6,7 @@ import json
 from s2sphere import CellId, LatLng
 from pgoapi.utilities import f2i
 from pokemongo_bot.human_behaviour import sleep, random_lat_long_delta
-from pokemongo_bot.cell_workers.utils import distance, i2f, format_time, convert_to_utf8
+from pokemongo_bot.utils import distance, i2f, format_time, convert_to_utf8
 import pokemongo_bot.logger as logger
 
 

--- a/pokemongo_bot/utils.py
+++ b/pokemongo_bot/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+from builtins import bytes, str
 import struct
 import time
 

--- a/pokemongo_bot/utils.py
+++ b/pokemongo_bot/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+# pylint: disable=redefined-builtin
 from builtins import bytes, str
 import struct
 import time


### PR DESCRIPTION
### Short Description:

Fixes various bugs from the Python 3 support branch.
### Changes:
- Force `logger.py` to use Python 3 types for strings even if running on Python 2.
- Move `utils.py` to bot directory since it doesn't make sense for it to be in `cell_workers`.

@OpenPoGo/maintainers
