### PR TITLE
Revert "Config and itemfile need int as key"

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -224,12 +224,6 @@ def init_config():
 
     config.exclude_plugins = config.exclude_plugins.split(",")
 
-    str_item_filter = config.__dict__.get("item_filter", {})
-    int_item_filter = {}
-    for item_id in str_item_filter:
-        int_item_filter[int(item_id)] = str_item_filter[item_id]
-    config.item_filter = int_item_filter
-
     print(config.__dict__)
 
     if config.auth_service not in ['ptc', 'google']:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -32,10 +32,8 @@ class PokemonGoBot(object):
 
     def __init__(self, config):
         self.config = config
+        self.item_list = json.load(open('data/items.json'))
         self.pokemon_list = json.load(open('data/pokemon.json'))
-        self.item_list = {}
-        for item_id, item_name in json.load(open('data/items.json')).iteritems():
-            self.item_list[int(item_id)] = item_name
 
         self.log = None
         self.stepper = None


### PR DESCRIPTION
Reverts OpenPoGo/OpenPoGoBot#132

Currently crashes on master:

[2016-07-31 21:45:58] [Transfer] Transferred 0 Pokemon.
Traceback (most recent call last):
  File "pokecli.py", line 279, in <module>
    main()
  File "pokecli.py", line 267, in main
    bot.start()
  File "/home/mleiter/Documents/OpenPoGoBot/pokemongo_bot/**init**.py", line 66, in start
    self._setup_api()
  File "/home/mleiter/Documents/OpenPoGoBot/pokemongo_bot/__init__.py", line 190, in _setup_api
    self.fire("item_bag_full")
  File "/home/mleiter/Documents/OpenPoGoBot/pokemongo_bot/__init__.py", line 73, in fire
    manager.fire_with_context(event, self, _args, *_kwargs)
  File "/home/mleiter/Documents/OpenPoGoBot/pokemongo_bot/event_manager.py", line 107, in fire_with_context
    return self.fire(event_name, _args, *_kwargs)
  File "/home/mleiter/Documents/OpenPoGoBot/pokemongo_bot/event_manager.py", line 101, in fire
    return self.events[event_name].fire(_args, *_kwargs)
  File "/home/mleiter/Documents/OpenPoGoBot/pokemongo_bot/event_manager.py", line 64, in fire
    return_dict = listener(**listener_args)
  File "./plugins/recycle_items/**init**.py", line 24, in filter_recyclable_items
    discard_quantity = current_quantity - max_keep_quantity
TypeError: unsupported operand type(s) for -: 'int' and 'dict'
