### PR TITLE
Non-english char fix

### DIFF
--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -43,6 +43,6 @@ def _log(text="", color="black", prefix=None):
     output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
-    print(output..encode('utf-8'))
+    print(output.encode('utf-8'))
     if LCD is not None and string is not None:
         LCD.message(string)

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -43,6 +43,6 @@ def _log(text="", color="black", prefix=None):
     output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
-    print(output)
+    print(output..encode('utf-8'))
     if LCD is not None and string is not None:
         LCD.message(string)


### PR DESCRIPTION
### Short Description: Non-english char fix
### Changes:
- Fixes UTF-8 encoded characters causing bot to crash

@OpenPoGo/maintainers
