### PR TITLE
Pokestop logging

### DIFF
--- a/pokemongo_bot/navigation/fort_navigator.py
+++ b/pokemongo_bot/navigation/fort_navigator.py
@@ -28,22 +28,22 @@ class FortNavigator(Navigator):
                 fort_id = fort.fort_id
                 dist = distance(self.stepper.current_lat, self.stepper.current_lng, lat, lng)
 
-                logger.log("[#] Found fort {} at distance {}".format(fort_id, format_dist(dist, unit)))
+                self.api_wrapper.fort_details(fort_id=fort_id,
+                                              latitude=lat,
+                                              longitude=lng)
+                response_dict = self.api_wrapper.call()
+                if response_dict is None:
+                    fort_name = fort_id
+                else:
+                    fort_name = response_dict["fort"].fort_name
+
+                logger.log("[#] Walking towards PokeStop \"{}\" ({} away)".format(fort_name, format_dist(dist, unit)))
 
                 if dist > 0:
-                    logger.log("[#] Need to move closer to Pokestop")
                     position = (lat, lng, 0.0)
 
                     self.stepper.walk_to(*position)
                     self.api_wrapper.player_update(latitude=lat, longitude=lng)
                     sleep(2)
 
-                self.api_wrapper.fort_details(fort_id=fort_id,
-                                              latitude=lat,
-                                              longitude=lng)
-                response_dict = self.api_wrapper.call()
-                if response_dict is None:
-                    return
-                fort_details = response_dict["fort"]
-                fort_name = fort_details.fort_name
-                logger.log("[#] Now at Pokestop: " + fort_name)
+                logger.log("[#] Now at PokeStop \"{}\"".format(fort_name))

--- a/pokemongo_bot/navigation/path_finder/google_path_finder.py
+++ b/pokemongo_bot/navigation/path_finder/google_path_finder.py
@@ -9,7 +9,9 @@ class GooglePathFinder(PathFinder):
 
     def path(self, from_lat, form_lng, to_lat, to_lng):
         # type: (float, float, float, float) -> List[(float, float)]
-        logger.log("[#] Asking google for directions")
+        if self.config.debug:
+            logger.log("[#] Asking google for directions")
+
         gmaps = googlemaps.Client(key=self.config.gmapkey)
 
         now = datetime.now()

--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -66,13 +66,15 @@ class Stepper(object):
         dist = distance(self.current_lat, self.current_lng, to_lat, to_lng)
         steps = (dist / (self.AVERAGE_STRIDE_LENGTH_IN_METRES * self.speed))
 
-        logger.log("[#] Walking from " + str((self.current_lat, self.current_lng)) + " to " + str(
-            str((to_lat, to_lng))) + " for approx. " + str(format_time(ceil(steps))))
+        if self.config.debug:
+            logger.log("[#] Walking from " + str((self.current_lat, self.current_lng)) + " to " + str(
+                str((to_lat, to_lng))) + " for approx. " + str(format_time(ceil(steps))))
+
         if steps != 0:
             d_lat = (to_lat - self.current_lat) / steps
             d_long = (to_lng - self.current_lng) / steps
 
-            for _ in range(int(steps)):
+            for _ in range(int(ceil(steps))):
                 c_lat = self.current_lat + d_lat + random_lat_long_delta(10)
                 c_long = self.current_lng + d_long + random_lat_long_delta(10)
                 self._jump_to(c_lat, c_long, to_alt)


### PR DESCRIPTION
### Short Description:

Logging output cleanup for navigation and pokestop spinning.

Closes #152
### Changes:
- `FortNavigatior` now reports fort names instead of IDs if it can
- `Walking from x to y` messages have been moved into debug mode
- `spin_pokestop` module will show pokestops if they are on cd in debug mode
- `Asking google for directions` moved to debug mode

@OpenPoGo/maintainers
