### PR TITLE
Added Egg incubation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Here are the available plugins:
 |     **Plugins**    |
 |:------------------:|
 | `catch_pokemon`    |
+| `egg_incubator`    |
 | `recycle_items`    |
 | `spin_pokestop`    |
 | `transfer_pokemon` |

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ $ python pokecli.py [flags]
 | --google-directions           | -gd                | Bot will use directions from google maps API to navigate                                                                                                                    |
 | --debug                       | -d                 | Debug Mode                                                                                                                                                                  |
 | --test                        | -t                 | Only parse the specified location                                                                                                                                           |
-| --fill-incubators             | -fi                | Fill incubators with eggs                                                                                                                                                   |
-| --use-all-incubators          | -ai                | Use all incubators or only unlimited one                                                                                                                                    |
+| --incubators-fill             | -fi                | Fill incubators with eggs                                                                                                                                                   |
+| --incubators-use-all          | -ia                | Use all incubators or only unlimited one                                                                                                                                    |
+| --incubators-priority         | -ip                | Priority of eggs to be incubated. Comma separated list of -ip="10km,5km,2km"                                                                                                |
+| --incubators-restrict         | -ir                | Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. -ir=\10km=901,5km=902"                                                                               |
 
 
 ### Command Line Example

--- a/plugins/egg_incubator/__init__.py
+++ b/plugins/egg_incubator/__init__.py
@@ -26,6 +26,8 @@ def incubate_eggs(bot, coords=None):
         incubators = [incu for incu in inventory["egg_incubators"] if incu.pokemon_id == 0 and (
             bot.config.incubation_use_all or incu.item_id == 901)]
 
+        in_use_count = len(inventory["egg_incubators"]) - len(incubators)
+
         # order eggs by distance longest -> shortest
         eggs_by_distance = sorted(eggs, key=lambda x: x.total_distance, reverse=True)
 
@@ -37,16 +39,18 @@ def incubate_eggs(bot, coords=None):
 
             for egg in eggs_by_distance:
                 if len(incubators) == 0:
-                    log("No more free incubators", "yellow")
+                    log("No more free incubators ({}/{} in use)".format(in_use_count, len(inventory["egg_incubators"])), "yellow")
                     return
 
                 if egg_restrictions is None:
                     incubator = incubators.pop()
                     bot.fire("incubate_egg", incubatior=incubator, egg=egg)
+                    in_use_count += 1
                 else:
                     for incubator in incubators:
                         if incubator.item_id in egg_restrictions:
                             bot.fire("incubate_egg", incubatior=incubator, egg=egg)
+                            in_use_count += 1
 
 
 @manager.on("incubate_egg")
@@ -55,4 +59,4 @@ def incubate_egg(bot, incubator=None, egg=None):
         return
 
     bot.api_wrapper.use_item_egg_incubator(item_id=incubator.unique_id, pokemon_id=egg.unique_id).call()
-    log("Put an {}km egg into an incubator".format(int(egg.total_distance)), "green")
+    log("Put a {}km egg into an incubator".format(int(egg.total_distance)), "green")

--- a/plugins/egg_incubator/__init__.py
+++ b/plugins/egg_incubator/__init__.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from pokemongo_bot import sleep
+from pokemongo_bot.event_manager import manager
+from pokemongo_bot import logger
+
+
+def log(text, color="black"):
+    logger.log(text, color=color, prefix="PokeStop")
+
+
+@manager.on("walking_started", priority=1000)
+def incubate_eggs(bot, coords=None):
+
+    if coords is None:
+        return
+
+    if bot.config.incubation_fill:
+
+        inventory = bot.update_player_and_inventory()
+
+        # Hatch any eggs that need to be hatched
+        bot.api_wrapper.get_hatched_eggs().call()
+        sleep(3)
+
+        eggs = [egg for egg in inventory["eggs"] if egg.egg_incubator_id == ""]
+        incubators = [incu for incu in inventory["egg_incubators"] if incu.pokemon_id == 0 and (
+            bot.config.incubation_use_all or incu.item_id == 901)]
+
+        # order eggs by distance longest -> shortest
+        eggs_by_distance = sorted(eggs, key=lambda x: x.total_distance, reverse=True)
+
+        for egg_distance in bot.config.incubation_priority:
+            try:
+                egg_restrictions = bot.config.incubation_restrict[egg_distance]
+            except KeyError:
+                egg_restrictions = None
+
+            for egg in eggs_by_distance:
+                if len(incubators) == 0:
+                    log("No more free incubators", "yellow")
+                    return
+
+                if egg_restrictions is None:
+                    incubator = incubators.pop()
+                    bot.fire("incubate_egg", incubatior=incubator, egg=egg)
+                else:
+                    for incubator in incubators:
+                        if incubator.item_id in egg_restrictions:
+                            bot.fire("incubate_egg", incubatior=incubator, egg=egg)
+
+
+@manager.on("incubate_egg")
+def incubate_egg(bot, incubator=None, egg=None):
+    if incubator is None or egg is None:
+        return
+
+    bot.api_wrapper.use_item_egg_incubator(item_id=incubator.unique_id, pokemon_id=egg.unique_id).call()
+    log("Put an {}km egg into an incubator".format(int(egg.total_distance)), "green")

--- a/plugins/egg_incubator/__init__.py
+++ b/plugins/egg_incubator/__init__.py
@@ -5,7 +5,7 @@ from pokemongo_bot import logger
 
 
 def log(text, color="black"):
-    logger.log(text, color=color, prefix="PokeStop")
+    logger.log(text, color=color, prefix="Incubator")
 
 
 @manager.on("walking_started", priority=1000)

--- a/pokecli.py
+++ b/pokecli.py
@@ -85,6 +85,15 @@ def init_config():
         "navigator_waypoints": [],
         "navigator_campsite": None,
         "path_finder": "google",
+
+        # incubation settings
+        "incubation_fill": False,
+        "incubation_use_all": False,
+        "incubation_priority": ["10km", "5km", "2km"],
+        "incubation_restrict": {
+            "2km": 901
+        },
+
         "debug": False,
         "test": False
     }
@@ -225,20 +234,31 @@ def init_config():
         dest="exclude_plugins")
 
     parser.add_argument(
-        "-fi",
-        "--fill-incubators",
+        "-if",
+        "--incubation-fill",
         help="Fill incubators with eggs",
         action="store_true",
-        dest="fill_incubators",
+        dest="incubation_fill",
         default=None)
-
     parser.add_argument(
-        "-ai",
-        "--use-all-incubators",
+        "-ia",
+        "--incubation-use-all",
         help="Use all incubators or only unlimited one",
         action="store_true",
-        dest="use_all_incubators",
+        dest="incubation_use_all",
         default=None)
+    parser.add_argument(
+        "-ip",
+        "--incubation-priority",
+        help="Priority of eggs to be incubated. Comma separated list of -ip=\"10km,5km,2km\"",
+        type=str,
+        dest="incubation_priority")
+    parser.add_argument(
+        "-ir",
+        "--incubation-restrict",
+        help="Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. -ir=\"10km=901,5km=902\"",
+        type=str,
+        dest="incubation_restrict")
 
     config = parser.parse_args()
 
@@ -266,6 +286,17 @@ def init_config():
     for item_id in str_item_filter:
         int_item_filter[int(item_id)] = str_item_filter[item_id]
     config.item_filter = int_item_filter
+
+    if isinstance(config.incubation_priority, str):
+        config.incubation_priority = config.incubation_priority.split(',')
+
+    if isinstance(config.incubation_restrict, str):
+        incubation_restrict_dict = {}
+        for key_value in config.incubation_restrict.split(','):
+            distance, incubator_id = key_value.split('=')
+            incubation_restrict_dict[distance] = incubator_id
+
+        config.incubation_restrict = incubation_restrict_dict
 
     print(config.__dict__)
 

--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -53,12 +53,15 @@ class Stepper(object):
         self.current_lng = position_lng
         self.current_alt = position_alt
 
+        self.bot.fire("walking_started", coords=(lat, lng, alt))
+
         # ask the path finder how to get there
         steps = self.path_finder.path(position_lat, position_lng, lat, lng)
         for step in steps:
             to_lat, to_lng = step
             self._walk_to(to_lat, to_lng, alt)
 
+        self.bot.fire("walking_finished", coords=(lat, lng, alt))
         logger.log("[#] Walking Finished")
 
     def _walk_to(self, to_lat, to_lng, to_alt):


### PR DESCRIPTION
### Short Description:

Incubate and hatch eggs when needed.

Closes #160 
### Changes:
- `config.incubation_fill`/`-if`/`--incubation-fill` - `True`/`False` to turn incubators on/off
- `config.incubation_use_all`/`-ia`/`--incubation-use-all` - `True`/`False` to use all incubatiors/only unlimited incubator
- `config.incubation_priority`/`-ip`/`--incubation-priority` - array/csv of egg distances to prioritise (`10km,5km,2km`)
- `config.incubation_restrict`/`-ir`/`--incubation-restrict``- dict/csv of egg distances to incubator ids to restrict where eggs are put (`10km=902,5km=902,2km=901`). Omitting a egg distance means no restrictions.

@OpenPoGo/maintainers
