### PR TITLE
fixed readme and example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ $ python pokecli.py [flags]
 | --google-directions           | -gd                | Bot will use directions from google maps API to navigate                                                                                                                    |
 | --debug                       | -d                 | Debug Mode                                                                                                                                                                  |
 | --test                        | -t                 | Only parse the specified location                                                                                                                                           |
-| --incubators-fill             | -fi                | Fill incubators with eggs                                                                                                                                                   |
-| --incubators-use-all          | -ia                | Use all incubators or only unlimited one                                                                                                                                    |
-| --incubators-priority         | -ip                | Priority of eggs to be incubated. Comma separated list of -ip="10km,5km,2km"                                                                                                |
-| --incubators-restrict         | -ir                | Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. -ir=\10km=901,5km=902"                                                                               |
+| --incubation-fill             | -if                | Fill incubators with eggs                                                                                                                                                   |
+| --incubation-use-all          | -ia                | Use all incubators or only unlimited one                                                                                                                                    |
+| --incubation-priority         | -ip                | Priority of eggs to be incubated. Comma separated list of -ip="10km,5km,2km"                                                                                                |
+| --incubation-restrict         | -ir                | Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. -ir="10km=901,5km=902"                                                                               |
 
 
 ### Command Line Example

--- a/config.json.example
+++ b/config.json.example
@@ -5,8 +5,12 @@
     "location": "SOME LOCATION",
     "gmapkey": "GOOGLE API KEY",
     "google_directions": true,
-    "fill_incubators":true,
-    "use_all_incubators":false,
+    "incubation_fill": false,
+    "incubation_use_all": false,
+    "incubation_priority": ["10km", "5km", "2km"],
+    "incubation_restrict": {
+        "2km": 901
+    },
     "cp": 100,
     "max_steps": 50,
     "walk": 4.16,


### PR DESCRIPTION
### Short Description:

Wrong (old) param names

@OpenPoGo/maintainers
