### PR TITLE
Unicode literals

### DIFF
--- a/plugins/egg_incubator/__init__.py
+++ b/plugins/egg_incubator/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from pokemongo_bot import sleep
 from pokemongo_bot.event_manager import manager
 from pokemongo_bot import logger

--- a/plugins/recycle_items/__init__.py
+++ b/plugins/recycle_items/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 from pokemongo_bot.event_manager import manager
 from pokemongo_bot import logger
 

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -68,7 +68,11 @@ def spin_pokestop(bot, pokestop=None):
                                                 latitude=pokestop.latitude,
                                                 longitude=pokestop.longitude).call()
     dist = distance(bot.stepper.current_lat, bot.stepper.current_lng, pokestop.latitude, pokestop.longitude)
-    log("Nearby PokeStop found \"{}\" ({} away)".format(fort_details["fort"].fort_name,
+    if platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system()[:6] == "CYGWIN":
+        fort_name = repr(fort_details["fort"].fort_name)
+    else
+        fort_name = fort_details["fort"].fort_name
+    log("Nearby PokeStop found \"{}\" ({} away)".format(fort_name,
                                                         format_dist(dist, bot.config.distance_unit)), color="yellow")
 
     log("Spinning...", color="yellow")

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 import time
-import platform
 from math import ceil
 
 from pokemongo_bot.human_behaviour import sleep

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import time
+import platform
 from math import ceil
 
 from pokemongo_bot.human_behaviour import sleep

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+from __future__ import unicode_literals
 import time
 import platform
 from math import ceil
@@ -69,11 +70,7 @@ def spin_pokestop(bot, pokestop=None):
                                                 latitude=pokestop.latitude,
                                                 longitude=pokestop.longitude).call()
     dist = distance(bot.stepper.current_lat, bot.stepper.current_lng, pokestop.latitude, pokestop.longitude)
-    if platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system()[:6] == "CYGWIN":
-        fort_name = repr(fort_details["fort"].fort_name)
-    else:
-        fort_name = fort_details["fort"].fort_name
-    log("Nearby PokeStop found \"{}\" ({} away)".format(fort_name,
+    log("Nearby PokeStop found \"{}\" ({} away)".format(fort_details["fort"].fort_name,
                                                         format_dist(dist, bot.config.distance_unit)), color="yellow")
 
     log("Spinning...", color="yellow")

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -71,7 +71,7 @@ def spin_pokestop(bot, pokestop=None):
     dist = distance(bot.stepper.current_lat, bot.stepper.current_lng, pokestop.latitude, pokestop.longitude)
     if platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system()[:6] == "CYGWIN":
         fort_name = repr(fort_details["fort"].fort_name)
-    else
+    else:
         fort_name = fort_details["fort"].fort_name
     log("Nearby PokeStop found \"{}\" ({} away)".format(fort_name,
                                                         format_dist(dist, bot.config.distance_unit)), color="yellow")

--- a/plugins/transfer_pokemon/__init__.py
+++ b/plugins/transfer_pokemon/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.event_manager import manager
 from pokemongo_bot import logger

--- a/plugins/web/__init__.py
+++ b/plugins/web/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from threading import Thread
 import os
 import logging

--- a/pokecli.py
+++ b/pokecli.py
@@ -26,6 +26,7 @@ Author: tjado <https://github.com/tejado>
 """
 
 from __future__ import print_function
+from __future__ import unicode_literals
 from getpass import getpass
 # pylint: disable=redefined-builtin
 from builtins import input

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+from __future__ import unicode_literals
 import datetime
 import json
 import logging

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -41,7 +41,7 @@ def _log(text="", color="black", prefix=None):
     output = u"[" + time.strftime("%Y-%m-%d %H:%M:%S") + u"] "
     if prefix is not None:
         output += u"[{}] ".format(str(prefix))
-    if platform.system() == "Windows" or platform.system() == "FreeBSD":
+    if platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system() == "CYGWIN_NT-6.1":
         output += repr(string)
     else:
         output += string

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from builtins import str
 import time
+import platform
 
 from colorama import Fore, Back, Style
 from pokemongo_bot.event_manager import manager
@@ -43,6 +44,9 @@ def _log(text="", color="black", prefix=None):
     output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
-    print(unicode(output))
+    if platform.system() == "Windows" || platform.system() == "FreeBSD":
+        print(output.encode('cp437', errors='replace').decode('cp437'))
+    else:
+        print(output)
     if LCD is not None and string is not None:
         LCD.message(string)

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-builtin
 from __future__ import print_function
+from __future__ import unicode_literals
 from builtins import str
 import time
 

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 from builtins import str
 import time
-import platform
 
 from colorama import Fore, Back, Style
 from pokemongo_bot.event_manager import manager
@@ -41,10 +40,7 @@ def _log(text="", color="black", prefix=None):
     output = u"[" + time.strftime("%Y-%m-%d %H:%M:%S") + u"] "
     if prefix is not None:
         output += u"[{}] ".format(str(prefix))
-    if platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system() == "CYGWIN_NT-6.1":
-        output += repr(string)
-    else:
-        output += string
+    output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
     print(output)

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -41,12 +41,12 @@ def _log(text="", color="black", prefix=None):
     output = u"[" + time.strftime("%Y-%m-%d %H:%M:%S") + u"] "
     if prefix is not None:
         output += u"[{}] ".format(str(prefix))
-    output += string
+    if platform.system() == "Windows" or platform.system() == "FreeBSD":
+        output += repr(string)
+    else:
+        output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
-    if platform.system() == "Windows" or platform.system() == "FreeBSD":
-        print(output.encode('cp437', errors='replace').decode('cp437'))
-    else:
-        print(output)
+    print(output)
     if LCD is not None and string is not None:
         LCD.message(string)

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -43,7 +43,6 @@ def _log(text="", color="black", prefix=None):
     output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
-    output = output.encode('utf-8')
-    print(output.decode('utf-8'))
+    print(unicode(output))
     if LCD is not None and string is not None:
         LCD.message(string)

--- a/pokemongo_bot/logger.py
+++ b/pokemongo_bot/logger.py
@@ -44,7 +44,7 @@ def _log(text="", color="black", prefix=None):
     output += string
     if color in color_hex:
         output = color_hex[color] + output + Style.RESET_ALL
-    if platform.system() == "Windows" || platform.system() == "FreeBSD":
+    if platform.system() == "Windows" or platform.system() == "FreeBSD":
         print(output.encode('cp437', errors='replace').decode('cp437'))
     else:
         print(output)

--- a/pokemongo_bot/navigation/camper_navigator.py
+++ b/pokemongo_bot/navigation/camper_navigator.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from math import floor
 
 from pokemongo_bot import logger

--- a/pokemongo_bot/navigation/fort_navigator.py
+++ b/pokemongo_bot/navigation/fort_navigator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import platform
 
 from pokemongo_bot import logger
 from pokemongo_bot.navigation.navigator import Navigator
@@ -34,6 +35,8 @@ class FortNavigator(Navigator):
                 response_dict = self.api_wrapper.call()
                 if response_dict is None:
                     fort_name = fort_id
+                elif platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system() == "CYGWIN_NT-6.1":
+                    fort_name = repr(response_dict["fort"].fort_name)
                 else:
                     fort_name = response_dict["fort"].fort_name
 

--- a/pokemongo_bot/navigation/fort_navigator.py
+++ b/pokemongo_bot/navigation/fort_navigator.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 from __future__ import unicode_literals
+from datetime import datetime
 import platform
 
 from pokemongo_bot import logger

--- a/pokemongo_bot/navigation/fort_navigator.py
+++ b/pokemongo_bot/navigation/fort_navigator.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from datetime import datetime
-import platform
 
 from pokemongo_bot import logger
 from pokemongo_bot.navigation.navigator import Navigator

--- a/pokemongo_bot/navigation/fort_navigator.py
+++ b/pokemongo_bot/navigation/fort_navigator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from __future__ import unicode_literals
 import platform
 
 from pokemongo_bot import logger
@@ -35,8 +36,6 @@ class FortNavigator(Navigator):
                 response_dict = self.api_wrapper.call()
                 if response_dict is None:
                     fort_name = fort_id
-                elif platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system()[:6] == "CYGWIN":
-                    fort_name = repr(response_dict["fort"].fort_name)
                 else:
                     fort_name = response_dict["fort"].fort_name
 

--- a/pokemongo_bot/navigation/fort_navigator.py
+++ b/pokemongo_bot/navigation/fort_navigator.py
@@ -35,7 +35,7 @@ class FortNavigator(Navigator):
                 response_dict = self.api_wrapper.call()
                 if response_dict is None:
                     fort_name = fort_id
-                elif platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system() == "CYGWIN_NT-6.1":
+                elif platform.system() == "Windows" or platform.system() == "FreeBSD" or platform.system()[:6] == "CYGWIN":
                     fort_name = repr(response_dict["fort"].fort_name)
                 else:
                     fort_name = response_dict["fort"].fort_name

--- a/pokemongo_bot/navigation/path_finder/google_path_finder.py
+++ b/pokemongo_bot/navigation/path_finder/google_path_finder.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from datetime import datetime
 import googlemaps
 

--- a/pokemongo_bot/navigation/waypoint_navigator.py
+++ b/pokemongo_bot/navigation/waypoint_navigator.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from pokemongo_bot import logger
 from pokemongo_bot.navigation.navigator import Navigator
 from pokemongo_bot.utils import distance, format_dist


### PR DESCRIPTION
### Short Description: Use unicode literals
### Changes:
- Use unicode literals instead of checking system type

@OpenPoGo/maintainers
