### PR TITLE
Fixed bug causing bot to walk on same spot

### DIFF
--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -97,8 +97,10 @@ class Stepper(object):
 
             total_steps = int(ceil(steps))
             for _ in range(total_steps):
-                c_lat = from_lat + d_lat + random_lat_long_delta(10)
-                c_long = from_lng + d_long + random_lat_long_delta(10)
+                from_lat += d_lat
+                from_lng += d_long
+                c_lat = from_lat + random_lat_long_delta(10)
+                c_long = from_lng + random_lat_long_delta(10)
                 step_locations.append((c_lat, c_long, alt))
 
         return step_locations


### PR DESCRIPTION
### Short Description:

The bot just walks on 1 point the jumps to the next pokestop as the position isn't incremented per step.

@OpenPoGo/maintainers
