### PR TITLE
Update to use new API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ release_config.json
 # Shared libraries
 encrypt.dll
 libencrypt.so
-libencrypt_darwin.so
+libencrypt-darwin.so
 encrypt.c

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ release_config.json
 # Sublime files
 *.sublime-project
 *.sublime-workspace
+
+# Shared libraries
+encrypt.dll
+libencrypt.so
+libencrypt_darwin.so

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ release_config.json
 encrypt.dll
 libencrypt.so
 libencrypt_darwin.so
+encrypt.c

--- a/README.md
+++ b/README.md
@@ -43,7 +43,24 @@ See [CONTRIBUTING.md](https://github.com/OpenPoGo/OpenPoGoBot/blob/master/CONTRI
 - [pip](https://pip.pypa.io/en/stable/installing/)
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [virtualenv](https://virtualenv.pypa.io/en/stable/installation/) (Optional)
+- `encrypt` shared library (OS Dependent, see below)
 - [protobuf 3](https://github.com/google/protobuf) (OS Dependent, see below)
+
+### `Encrypt` shared library
+
+With the changes to the API on 3 August 2016, API map requests are required to have a `Signature` field in the request body. This requires that the `encrypt` shared library is in the bot directory, as it is needed to encrypt one of the fields.
+
+You will need to either find `encrypt.c` or the appropriate shared library for your system. The bot will automatically attempt to load the following filenames; another filename can be specified using config options as described below.
+
+- OS X: `libencrypt-darwin.so`
+- Windows: `encrypt.dll`
+- Linux: `libencrypt.so`
+
+To build the shared library for Windows, run `lib/build_dll.bat`, rename the resulting binary to `encrypt.dll` and move to the bot folder.
+
+To build the shared library for OS X or Linux, in the `lib` folder run `make`, rename the resulting binary as needed and move to the bot folder.
+
+Note that if you are running a 32-bit version of Python, you must have a 32-bit version of the library, and vice versa for 64-bit. On Windows, failure to do so will result in `WindowsError: [Error 193] %1 is not a valid Win32 application`.
 
 ### Protobuf 3 installation
 
@@ -94,6 +111,7 @@ $ python pokecli.py [flags]
 | `--incubation-use-all`          | `-ia`                | Use all incubators (instead of only the unlimited one)                                                                                                                                      |
 | `--incubation-priority`         | `-ip`                | Priority of eggs to be incubated. Comma separated list of `-ip='10km,5km,2km'`                                                                                                              |
 | `--incubation-restrict`         | `-ir`                | Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. `-ir='10km=901,5km=902'`                                                                                             |
+| `--load-library [LIB]`          | `-lib [LIB]`         | Load the `encrypt` shared library for signing Signature fields in requests from the specified path.                                                                                         |
 
 
 ### Command Line Example
@@ -204,3 +222,4 @@ Here are the available plugins:
 - [AeonLucid](https://github.com/AeonLucid/POGOProtos) for improved protos
 - [AHAAAAAAA](https://github.com/AHAAAAAAA/PokemonGo-Map) for parts of the s2sphere stuff
 - [PokemonGoF](https://github.com/PokemonGoF/PokemonGo-bot) and all contributors for the original bot this fork is based on
+- [/r/PokemonGoDev](https://github.com/keyphact/pgoapi) and all reverse engineering contributors for fixes for the new API changes

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -101,12 +101,10 @@ class PoGoApi(object):
                 print("[API] Requesting too fast. Retrying in 10 seconds...")
                 time.sleep(10)
                 continue
-            """
             except TypeError:
                 print("[API] Failed to perform API call (servers might be offline). Retrying in 10 seconds...")
                 time.sleep(10)
                 continue
-            """
 
             if results is False or results is None or results.get('status_code', 1) != 1:
                 print("[API] API call failed. Retrying in 10 seconds...")

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -9,7 +9,7 @@ from .state_manager import StateManager
 
 
 class PoGoApi(object):
-    def __init__(self, provider="google", username="", password=""):
+    def __init__(self, provider="google", username="", password="", shared_lib="encrypt.dll"):
         self._api = PGoApi()
 
         self.provider = provider
@@ -22,6 +22,8 @@ class PoGoApi(object):
 
         self._pending_calls = {}
         self._pending_calls_keys = []
+
+        self._api.activate_signature(shared_lib)
 
     def login(self):
         try:
@@ -99,10 +101,12 @@ class PoGoApi(object):
                 print("[API] Requesting too fast. Retrying in 10 seconds...")
                 time.sleep(10)
                 continue
+            """
             except TypeError:
                 print("[API] Failed to perform API call (servers might be offline). Retrying in 10 seconds...")
                 time.sleep(10)
                 continue
+            """
 
             if results is False or results is None or results.get('status_code', 1) != 1:
                 print("[API] API call failed. Retrying in 10 seconds...")

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,0 +1,18 @@
+CC ?= cc
+CFLAGS ?= -g -fPIC
+LDFLAGS ?=
+
+LIBENCRYPT_OBJS = encrypt.o
+TEST_OBJS = main.o
+OBJS = $(LIBENCRYPT_OBJS) $(TEST_OBJS)
+TARGETS = libencrypt.so
+
+all: $(TARGETS)
+
+libencrypt.so: $(LIBENCRYPT_OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $(LIBENCRYPT_OBJS) -lm
+
+lib: libencrypt.so
+
+clean:
+	$(RM) $(OBJS) $(TARGETS)

--- a/lib/build_dll.bat
+++ b/lib/build_dll.bat
@@ -1,0 +1,2 @@
+@echo off
+cl encrypt.c /link /dll /out:encrypt.dll /export:encrypt

--- a/lib/encrypt.h
+++ b/lib/encrypt.h
@@ -1,0 +1,8 @@
+#ifndef ENCRYPT_H
+#define ENCRYPT_H
+
+extern int encrypt(const unsigned char *input, size_t input_size,
+    const unsigned char* iv, size_t iv_size,
+    unsigned char* output, size_t * output_size);
+
+#endif

--- a/plugins/catch_pokemon/__init__.py
+++ b/plugins/catch_pokemon/__init__.py
@@ -117,7 +117,7 @@ def throw_pokeball(bot, encounter_id, pokeball, spawn_point_id, pokemon):
         return False, None
     pokemon_catch_response = response["encounter"]
     status = pokemon_catch_response.status
-    pokemon_name = bot.pokemon_list[pokemon.pokemon_id]["Name"]
+    pokemon_name = bot.pokemon_list[pokemon.pokemon_id - 1]["Name"]
     if status is 2:
         log('Failed to capture {}. Trying again!'.format(pokemon_name), 'yellow')
         bot.fire("pokemon_catch_failed", pokemon=pokemon)

--- a/pokecli.py
+++ b/pokecli.py
@@ -104,7 +104,7 @@ def init_config():
     elif platform.system() == "Linux":
         default_config["load_library"] = "libencrypt.so"
     elif platform.system() == "Darwin":
-        default_config["load_library"] = "libencrypt_darwin.so"
+        default_config["load_library"] = "libencrypt-darwin.so"
 
     parser = argparse.ArgumentParser()
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -34,6 +34,7 @@ import argparse
 import ssl
 import logging
 import sys
+import platform
 
 from pokemongo_bot import logger
 from pokemongo_bot import PokemonGoBot
@@ -97,6 +98,13 @@ def init_config():
         "debug": False,
         "test": False
     }
+
+    if platform.system() == "Windows":
+        default_config["load_library"] = "encrypt.dll"
+    elif platform.system() == "Linux":
+        default_config["load_library"] = "libencrypt.so"
+    elif platform.system() == "Darwin":
+        default_config["load_library"] = "libencrypt_darwin.so"
 
     parser = argparse.ArgumentParser()
 
@@ -259,6 +267,12 @@ def init_config():
         help="Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. -ir=\"10km=901,5km=902\"",
         type=str,
         dest="incubation_restrict")
+    parser.add_argument(
+        "-lib",
+        "--load-library",
+        help="Specify which shared library to use to generate Signature fields in requests.",
+        type=str,
+        dest="load_library")
 
     config = parser.parse_args()
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -139,7 +139,7 @@ class PokemonGoBot(object):
     def _setup_api(self):
         # instantiate api
         self.api_wrapper = PoGoApi(provider=self.config.auth_service, username=self.config.username,
-                                   password=self.config.password)
+                                   password=self.config.password, shared_lib=self.config.load_library)
         # provide player position on the earth
 
         self._set_starting_position()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ greenlet==0.4.10
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
--e git+https://github.com/tejado/pgoapi.git@e7c395523e25e357215bb16ac243103f846ddc5b#egg=pgoapi-dev
+-e git+https://github.com/keyphact/pgoapi.git@06eaef1e0353d17f775f2d1765d6281a05be7654#egg=pgoapi-dev
 protobuf==3.0.0b4
 protobuf-to-dict==0.1.0
 pycryptodomex==3.4.2


### PR DESCRIPTION
### Short Description:

Switches from tejado's pgoapi to the /r/pokemongodev pgoapi repo to work around the 3 August 2016 API changes.
### Changes:
- Switched to https://github.com/keyphact/pgoapi.
- Added instructions to README for `encrypt` shared library.
- Added config option to load shared library from a specified location.

@OpenPoGo/maintainers
