### PR TITLE
Use in-game item names

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,10 +1,10 @@
 {
     "0": "Unknown",
 
-    "1": "Pokeball",
-    "2": "Greatball",
-    "3": "Ultraball",
-    "4": "Masterball",
+    "1": "Poke Ball",
+    "2": "Great Ball",
+    "3": "Ultra Ball",
+    "4": "Master Ball",
 
     "101": "Potion",
     "102": "Super Potion",
@@ -21,7 +21,7 @@
     "403": "Cool Incense",
     "404": "Floral Incense",
 
-    "501": "Troy Disk",
+    "501": "Lure Module",
 
     "602": "X Attack",
     "603": "X Defense",


### PR DESCRIPTION
### Short Description:

Use in-game item names
### Changes:

This corrects the item names to match the names in the official game client.

(The only remaining difference is “Poke Ball” vs. “Poké Ball”, but that’s part of a bigger issue involving Unicode support.)

@OpenPoGo/maintainers
