### PR TITLE
.gitignore: Add *.so and *.o

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,6 @@ api-test.txt
 
 # Shared libraries
 encrypt.dll
-libencrypt.so
-libencrypt-darwin.so
 encrypt.c
+*.so
+*.o


### PR DESCRIPTION
### Short Description:

This adds `*.so` and `*.o` to `.gitignore` so that adding such files doesn’t make the tree dirty.

This PR supersedes #214.

@OpenPoGo/maintainers
