### PR TITLE
Changes to make the bot not walk directly under a pokestop to spin it.

### DIFF
--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -40,7 +40,7 @@ def visit_near_pokestops(bot, pokestops=None):
     for pokestop in pokestops:
         dist = distance(bot.stepper.current_lat, bot.stepper.current_lng, pokestop.latitude, pokestop.longitude)
 
-        if dist < 15:
+        if dist < 35:
             if pokestop.is_in_cooldown() is False:
                 manager.fire_with_context('pokestop_arrived', bot, pokestop=pokestop)
             elif bot.config.debug:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -175,6 +175,7 @@ class PokemonGoBot(object):
             inventory = response_dict['inventory']
             self.candies = response_dict['candy']
             pokemon = response_dict['pokemon']
+            eggs = response_dict['eggs']
             creation_date = player.get_creation_date()
 
             balls_stock = self.pokeball_inventory()
@@ -186,7 +187,7 @@ class PokemonGoBot(object):
             logger.log('[#] Username: {}'.format(player.username))
             logger.log('[#] Acccount creation: {}'.format(creation_date))
             logger.log('[#] Bag storage: {}/{}'.format(inventory["count"], player.max_item_storage))
-            logger.log('[#] Pokemon storage: {}/{}'.format(len(pokemon), player.max_pokemon_storage))
+            logger.log('[#] Pokemon storage: {}/{}'.format(len(pokemon) + len(eggs), player.max_pokemon_storage))
             logger.log('[#] Stardust: {}'.format(stardust))
             logger.log('[#] Pokecoins: {}'.format(pokecoins))
             logger.log('[#] Poke Balls: {}'.format(balls_stock[1]))

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -116,8 +116,8 @@ class PokemonGoBot(object):
                     self.mapper.get_cells_at_current_position()
                 )
 
-            position_lat = destination.target_lat
-            position_lng = destination.target_lng
+            position_lat = self.stepper.current_lat
+            position_lng = self.stepper.current_lng
 
     def work_on_cells(self, map_cells):
         # type: (Cell, bool) -> None

--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -60,6 +60,8 @@ class Stepper(object):
 
         for step in destination.step():
             self._step_to(*step)
+            if distance(self.current_lat, self.current_lng, destination.target_lat, destination.target_lng) < 30:
+                break
             yield step
 
         if destination.name:


### PR DESCRIPTION
### Short Description: Changes to make the bot not walk directly under a pokestop to spin it.
### Changes:

Should walk to within 30 meters then switch to next fort.
Also changed the spinner to trigger within 35 meters.
