### PR TITLE
add web to default exclude plugin

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -37,5 +37,6 @@
     "path_finder": "google",
     "navigator": "fort",
     "navigator_waypoints": [],
-    "navigator_campsite": null
+    "navigator_campsite": null,
+    "exclude_plugins": "web"
 }


### PR DESCRIPTION
### Short Description:

add web to default exclude plugin
### Changes:
- socket and web don't work well together

@OpenPoGo/maintainers
