### PR TITLE
Changes to make the bot not walk directly under a pokestop to spin it.

### DIFF
--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -40,7 +40,7 @@ def visit_near_pokestops(bot, pokestops=None):
     for pokestop in pokestops:
         dist = distance(bot.stepper.current_lat, bot.stepper.current_lng, pokestop.latitude, pokestop.longitude)
 
-        if dist < 15:
+        if dist < 35:
             if pokestop.is_in_cooldown() is False:
                 manager.fire_with_context('pokestop_arrived', bot, pokestop=pokestop)
             elif bot.config.debug:

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -103,21 +103,24 @@ class PokemonGoBot(object):
         # Work on all the initial cells
         self.work_on_cells(map_cells)
 
-        position_lat = self.stepper.current_lat
-        position_lng = self.stepper.current_lng
-
         for destination in self.navigator.navigate(map_cells):
+            position_lat = self.stepper.current_lat
+            position_lng = self.stepper.current_lng
+
             destination.set_steps(
-                self.stepper.get_route_between(position_lat, position_lng, destination.target_lat, destination.target_lng, destination.target_alt)
+                self.stepper.get_route_between(
+                    position_lat,
+                    position_lng,
+                    destination.target_lat,
+                    destination.target_lng,
+                    destination.target_alt
+                )
             )
 
             for _ in self.stepper.step(destination):
                 self.work_on_cells(
                     self.mapper.get_cells_at_current_position()
                 )
-
-            position_lat = destination.target_lat
-            position_lng = destination.target_lng
 
     def work_on_cells(self, map_cells):
         # type: (Cell, bool) -> None

--- a/pokemongo_bot/stepper.py
+++ b/pokemongo_bot/stepper.py
@@ -56,6 +56,8 @@ class Stepper(object):
                        prefix="Navigation")
 
         for step in destination.step():
+            if distance(self.current_lat, self.current_lng, destination.target_lat, destination.target_lng) < 30:
+                break
             self._step_to(*step)
             yield step
 


### PR DESCRIPTION
### Short Description: Changes to make the bot not walk directly under a pokestop to spin it.
### Changes:

Should walk to within 30 meters then switch to next fort.
Also changed the spinner to trigger within 35 meters.
@OpenPoGo/maintainers
