### PR TITLE
add pokemon settings for evolution logic

### DIFF
--- a/api/state_manager.py
+++ b/api/state_manager.py
@@ -28,7 +28,8 @@ class StateManager(object):
             "RECYCLE_INVENTORY_ITEM": self._noop,
             "USE_ITEM_EGG_INCUBATOR": self._parse_use_incubator,
             "GET_HATCHED_EGGS": self._parse_get_hatched_eggs,
-            "EVOLVE_POKEMON": self._parse_evolution
+            "EVOLVE_POKEMON": self._parse_evolution,
+            "DOWNLOAD_ITEM_TEMPLATES": self._identity
         }
 
         # Maps methods to the state objects that they refresh.
@@ -47,7 +48,8 @@ class StateManager(object):
             "FORT_DETAILS": ["fort"],
             "FORT_SEARCH": [],
             "RECYCLE_INVENTORY_ITEM": [],
-            "EVOLVE_POKEMON": ["evolution"]
+            "EVOLVE_POKEMON": ["evolution"],
+            "DOWNLOAD_ITEM_TEMPLATES": []
         }
 
         # Maps methods to the state objects that they invalidate.
@@ -70,7 +72,8 @@ class StateManager(object):
             "FORT_DETAILS": ["fort"],
             "FORT_SEARCH": ["player", "inventory", "eggs"],
             "RECYCLE_INVENTORY_ITEM": ["inventory"],
-            "EVOLVE_POKEMON": ["player", "inventory", "pokemon", "pokedex", "candy"]
+            "EVOLVE_POKEMON": ["player", "inventory", "pokemon", "pokedex", "candy"],
+            "DOWNLOAD_ITEM_TEMPLATES": []
         }
 
         self.current_state = {}

--- a/api/state_manager.py
+++ b/api/state_manager.py
@@ -46,10 +46,10 @@ class StateManager(object):
             "RELEASE_POKEMON": [],
             "PLAYER_UPDATE": [],
             "FORT_DETAILS": ["fort"],
-            "FORT_SEARCH": [],
+            "FORT_SEARCH": ["FORT_SEARCH"],
             "RECYCLE_INVENTORY_ITEM": [],
             "EVOLVE_POKEMON": ["evolution"],
-            "DOWNLOAD_ITEM_TEMPLATES": []
+            "DOWNLOAD_ITEM_TEMPLATES": ["DOWNLOAD_ITEM_TEMPLATES"]
         }
 
         # Maps methods to the state objects that they invalidate.

--- a/plugins/socket/botevents.py
+++ b/plugins/socket/botevents.py
@@ -27,9 +27,6 @@ def register_bot_events(socketio, state):
             }
         }
 
-        # templates = bot.api_wrapper.download_item_templates().call()
-        # print templates
-
         # reinit state
         state.update(emitted_object)
         state["bot"] = bot

--- a/plugins/socket/uievents.py
+++ b/plugins/socket/uievents.py
@@ -26,6 +26,16 @@ def register_ui_events(socketio, state):
     def disconnect():
         logger.log("Web client disconnected", "yellow", fire_event=False)
 
+    @socketio.on("pokemon_settings", namespace="/event")
+    def client_ask_for_pokemon_settings():
+        if "bot" in state:
+            bot = state["bot"]
+            templates = bot.api_wrapper.download_item_templates().call(ignore_cache=True)
+            templates = templates["DOWNLOAD_ITEM_TEMPLATES"]["item_templates"]
+            pokemon_settings = [t["pokemon_settings"] for t in templates if "pokemon_settings" in t]
+            pokemon_settings = sorted(pokemon_settings, key=lambda p: p["pokemon_id"])
+            socketio.emit("pokemon_settings", pokemon_settings, namespace="/event", room=request.sid)
+
     @socketio.on("pokemon_list", namespace="/event")
     def client_ask_for_pokemon_list():
         if "bot" in state:

--- a/plugins/socket/uievents.py
+++ b/plugins/socket/uievents.py
@@ -30,7 +30,7 @@ def register_ui_events(socketio, state):
     def client_ask_for_pokemon_settings():
         if "bot" in state:
             bot = state["bot"]
-            templates = bot.api_wrapper.download_item_templates().call(ignore_cache=True)
+            templates = bot.api_wrapper.download_item_templates().call()
             templates = templates["DOWNLOAD_ITEM_TEMPLATES"]["item_templates"]
             pokemon_settings = [t["pokemon_settings"] for t in templates if "pokemon_settings" in t]
             pokemon_settings = sorted(pokemon_settings, key=lambda p: p["pokemon_id"])


### PR DESCRIPTION
### Short Description:

add pokemon settings for evolution logic
can tell you family id, candy to evolve, etc... 
data is ask to the server to be up to date
### Changes:
- respond to pokemon_settings event and send pokemon_settings 

@OpenPoGo/maintainers
