### PR TITLE
Issue #271 - Added random delay in front of the api calls

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -101,8 +101,7 @@ class PoGoApi(object):
                 getattr(request, method)(*my_args, **my_kwargs)
 			
             # random request delay to prevent status code 52: too many requests
-            api_cd = random.uniform(0.5, 1.5)
-            time.sleep(api_cd)
+            time.sleep(random.uniform(0.5, 1.5))
 			
             try:
                 results = request.call()

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -99,10 +99,10 @@ class PoGoApi(object):
             for method in uncached_method_keys:
                 my_args, my_kwargs = methods[method]
                 getattr(request, method)(*my_args, **my_kwargs)
-			
+
             # random request delay to prevent status code 52: too many requests
             time.sleep(random.uniform(0.5, 1.5))
-			
+
             try:
                 results = request.call()
             except ServerSideRequestThrottlingException:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import time
+import random
 
 from six import integer_types
 from pgoapi import PGoApi                                           # type: ignore
@@ -98,7 +99,11 @@ class PoGoApi(object):
             for method in uncached_method_keys:
                 my_args, my_kwargs = methods[method]
                 getattr(request, method)(*my_args, **my_kwargs)
-
+			
+            # random request delay to prevent status code 52: too many requests
+            api_cd = random.uniform(0.5, 1.5)
+            time.sleep(api_cd)
+			
             try:
                 results = request.call()
             except ServerSideRequestThrottlingException:


### PR DESCRIPTION
### Short Description:

Prevents all "[API] Requesting too fast. Retrying in 10 seconds..." notices so far.
Suggested by @robertyu in Issue #271 
### Changes:
- added a delay to the api (0.5 - 1.5) calls, to prevent status code 52: too many requests.

@OpenPoGo/maintainers
