### PR TITLE
Visit PokeStop - Bag Full (xp are still awarded)

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -101,8 +101,7 @@ class PoGoApi(object):
                 getattr(request, method)(*my_args, **my_kwargs)
 			
             # random request delay to prevent status code 52: too many requests
-            api_cd = random.uniform(0.5, 1.5)
-            time.sleep(api_cd)
+            time.sleep(random.uniform(0.5, 1.5))
 			
             try:
                 results = request.call()

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -99,10 +99,10 @@ class PoGoApi(object):
             for method in uncached_method_keys:
                 my_args, my_kwargs = methods[method]
                 getattr(request, method)(*my_args, **my_kwargs)
-			
+
             # random request delay to prevent status code 52: too many requests
             time.sleep(random.uniform(0.5, 1.5))
-			
+
             try:
                 results = request.call()
             except ServerSideRequestThrottlingException:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import time
+import random
 
 from six import integer_types
 from pgoapi import PGoApi                                           # type: ignore
@@ -98,7 +99,11 @@ class PoGoApi(object):
             for method in uncached_method_keys:
                 my_args, my_kwargs = methods[method]
                 getattr(request, method)(*my_args, **my_kwargs)
-
+			
+            # random request delay to prevent status code 52: too many requests
+            api_cd = random.uniform(0.5, 1.5)
+            time.sleep(api_cd)
+			
             try:
                 results = request.call()
             except ServerSideRequestThrottlingException:

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -134,15 +134,14 @@ def spin_pokestop(bot, pokestop=None):
             cooldown_time = str(format_time((pokestop_cooldown / 1000) - seconds_since_epoch))
             log("PokeStop is already on cooldown for {}.".format(cooldown_time), "red")
     elif spin_result == 4:
-        log("Loot: ", "green")
-
         manager.fire_with_context('pokestop_visited', bot, pokestop=pokestop)
 
         experience_awarded = spin_details.get("experience_awarded", False)
         if experience_awarded:
+            log("Loot: ", "green")
             log("+ {} XP".format(experience_awarded), "green")
 
-        log("+ Item bag is full.", "red")
+        log("Item bag is full.", "red")
 
         bot.fire("item_bag_full")
 

--- a/plugins/spin_pokestop/__init__.py
+++ b/plugins/spin_pokestop/__init__.py
@@ -134,8 +134,20 @@ def spin_pokestop(bot, pokestop=None):
             cooldown_time = str(format_time((pokestop_cooldown / 1000) - seconds_since_epoch))
             log("PokeStop is already on cooldown for {}.".format(cooldown_time), "red")
     elif spin_result == 4:
-        log("Item bag is full.", "red")
+        log("Loot: ", "green")
+
+        manager.fire_with_context('pokestop_visited', bot, pokestop=pokestop)
+
+        experience_awarded = spin_details.get("experience_awarded", False)
+        if experience_awarded:
+            log("+ {} XP".format(experience_awarded), "green")
+
+        log("+ Item bag is full.", "red")
+
         bot.fire("item_bag_full")
+
+        if not experience_awarded and not pokestop_cooldown:
+            log("Might be softbanned, try again later.", "red")
     else:
         log("I don't know what happened! Maybe servers are down?", "red")
 


### PR DESCRIPTION
### Short Description:

When you visit a pokestop, you still get xp - even if your item bag is full.
Log didn't inform about that and didn't fire the pokestop visited event.
The pokestop is visited successfully after all, only item's are not given out - xp are recieved.
### Changes:
- Modified the message's and added the pokestop_visited event
- Added the softban notification

@OpenPoGo/maintainers
