### PR TITLE
Added configuration for socket host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ $ python pokecli.py [flags]
 | `--incubation-priority`         | `-ip`                | Priority of eggs to be incubated. Comma separated list of `-ip='10km,5km,2km'`                                                                                                              |
 | `--incubation-restrict`         | `-ir`                | Restrict an egg to an incubator. List of <distance=incubator_id>. E.g. `-ir='10km=901,5km=902'`                                                                                             |
 | `--load-library [LIB]`          | `-lib [LIB]`         | Load the `encrypt` shared library for signing Signature fields in requests from the specified path.                                                                                         |
+| `--socket-host [HOST]`          | `-sh [HOST]`         | Host to mount the socket server on.                                                                                                                                                         |
+| `--socket-port [PORT]`          | `-sp [PORT]`         | Port to mount the socket server on.                                                                                                                                                         |
 
 
 ### Command Line Example

--- a/config.json.example
+++ b/config.json.example
@@ -39,4 +39,6 @@
     "navigator_waypoints": [],
     "navigator_campsite": null,
     "exclude_plugins": ""
+    "socket_host": "0.0.0.0",
+    "socket_port": "8000"
 }

--- a/plugins/socket/__init__.py
+++ b/plugins/socket/__init__.py
@@ -13,11 +13,21 @@ from plugins.socket import uievents
 
 # pylint: disable=unused-variable, unused-argument
 
-logging.getLogger('socketio').disabled = True
-logging.getLogger('engineio').disabled = True
-logging.getLogger('werkzeug').disabled = True
+@manager.on('bot_setup')
+def boot(bot=None):
+    if bot is None:
+        return
 
-def run_socket_server():
+    SOCKET_THREAD = Thread(target=run_socket_server, args=(bot.config.socket_host, bot.config.socket_port,))
+    SOCKET_THREAD.daemon = True
+    SOCKET_THREAD.start()
+
+
+def log(text, color="black"):
+    logger.log(text, color=color, prefix="Socket")
+
+
+def run_socket_server(host='0.0.0.0', port=8000):
     app = Flask(__name__)
     app.config["SECRET_KEY"] = "OpenPoGoBotSocket"
     socketio = SocketIO(app, logging=False, engineio_logger=False, json=myjson)
@@ -31,11 +41,5 @@ def run_socket_server():
     botevents.register_bot_events(socketio, state)
     uievents.register_ui_events(socketio, state)
 
-    socketio.run(app, host="0.0.0.0", port=8000, debug=False, use_reloader=False, log_output=False)
-
-
-# prevent starting the thread already on imports
-if __name__ == "__init__":
-    SOCKET_THREAD = Thread(target=run_socket_server)
-    SOCKET_THREAD.daemon = True
-    SOCKET_THREAD.start()
+    socketio.run(app, host=host, port=port, debug=False, use_reloader=False, log_output=False)
+    log('Server started on {}:{}'.format(host, port))

--- a/pokecli.py
+++ b/pokecli.py
@@ -98,6 +98,9 @@ def init_config():
             "2km": 901
         },
 
+        "socket_host": "0.0.0.0",
+        "socket_port": 8000,
+
         "debug": False,
         "test": False,
         "print_events": False
@@ -292,6 +295,18 @@ def init_config():
         help="Specify which shared library to use to generate Signature fields in requests.",
         type=str,
         dest="load_library")
+    parser.add_argument(
+        "-sh",
+        "--socket-host",
+        help="Host to mount the socket server on.",
+        type=str,
+        dest="socket_host")
+    parser.add_argument(
+        "-sp",
+        "--socket-port",
+        help="Port to mount the socket server on.",
+        type=str,
+        dest="socket_port")
 
     config = parser.parse_args()
 

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -74,6 +74,8 @@ class PokemonGoBot(object):
         self._setup_api()
         random.seed()
 
+        self.fire('bot_setup')
+
         self.stepper = Stepper(self)
         self.mapper = Mapper(self)
 


### PR DESCRIPTION
### Short Description:

Allows the socket server host and port to be configurable to avoid host and/or port clashing.
### Changes:
- Added `--socket-host` and `--socket-port` options

@OpenPoGo/maintainers
