### PR TITLE
Fix backwards transfer logic

### DIFF
--- a/api/inventory_parser.py
+++ b/api/inventory_parser.py
@@ -8,7 +8,7 @@ class InventoryParser(JSONEncodable):
         data = data.get("inventory_delta", {})
         self.last_updated = data.get("new_timestamp_ms", 0)
 
-        items = data.get("inventory_items", 0)
+        items = data.get("inventory_items", [])
         self.items = {"count": 0}
         self.candy = {}
         self.pokedex_entries = {}

--- a/api/pokemon.py
+++ b/api/pokemon.py
@@ -34,7 +34,7 @@ class Pokemon(JSONEncodable):
         self.weight = data.get("weight_kg", 0.0)
         self.origin = data.get("origin", 0)
 
-        self.favorite = data.get("favorite", 0) == True
+        self.favorite = data.get("favorite", 0) == 1
         self.nickname = data.get("nickname", None)
 
         self.deployed_fort_id = data.get("deployed_fort_id", None)

--- a/api/pokemon.py
+++ b/api/pokemon.py
@@ -2,7 +2,6 @@ from api.json_encodable import JSONEncodable
 
 
 class Egg(JSONEncodable):
-
     def __init__(self, data):
         self.unique_id = data.get("id", 0)
         self.walked_distance = data.get("egg_km_walked_start", 0.0)
@@ -13,9 +12,7 @@ class Egg(JSONEncodable):
 
 
 class Pokemon(JSONEncodable):
-
     def __init__(self, data):
-        self.data = data
         self.unique_id = data.get("id", 0)
         self.pokemon_id = data.get("pokemon_id", 0)
         self.hp = data.get("individual_stamina", 0)
@@ -35,5 +32,10 @@ class Pokemon(JSONEncodable):
         self.captured_cell_id = data.get("captured_cell_id", 0)
         self.height = data.get("height_m", 0.0)
         self.weight = data.get("weight_kg", 0.0)
+        self.origin = data.get("origin", 0)
+
+        self.favorite = data.get("favorite", 0) == True
+        self.nickname = data.get("nickname", None)
 
         self.deployed_fort_id = data.get("deployed_fort_id", None)
+        self.from_fort = data.get("from_fort", None)

--- a/plugins/catch_pokemon/__init__.py
+++ b/plugins/catch_pokemon/__init__.py
@@ -116,7 +116,7 @@ def throw_pokeball(bot, encounter_id, pokeball, spawn_point_id, pokemon, pos):
                                   normalized_hit_position=1)
     response = bot.api_wrapper.call()
     if response is None:
-        return False, None
+        return False
     pokemon_catch_response = response["encounter"]
     status = pokemon_catch_response.status
     pokemon_name = bot.pokemon_list[pokemon.pokemon_id - 1]["Name"]
@@ -136,5 +136,5 @@ def throw_pokeball(bot, encounter_id, pokeball, spawn_point_id, pokemon, pos):
         candy = pokemon_catch_response.candy
         bot.add_candies(name=pokemon_name, pokemon_candies=candy)
         log("Rewards: {} XP, {} Stardust, {} Candy".format(xp, stardust, candy), "green")
-        bot.fire("pokemon_caught", pokemon=pokemon, position=pos)
+        bot.fire("pokemon_caught", transfer_list=[pokemon], position=pos)
         return False

--- a/plugins/catch_pokemon/__init__.py
+++ b/plugins/catch_pokemon/__init__.py
@@ -136,5 +136,5 @@ def throw_pokeball(bot, encounter_id, pokeball, spawn_point_id, pokemon, pos):
         candy = pokemon_catch_response.candy
         bot.add_candies(name=pokemon_name, pokemon_candies=candy)
         log("Rewards: {} XP, {} Stardust, {} Candy".format(xp, stardust, candy), "green")
-        bot.fire("pokemon_caught", transfer_list=[pokemon], position=pos)
+        bot.fire("pokemon_caught", pokemon=pokemon, position=pos)
         return False

--- a/plugins/transfer_pokemon/__init__.py
+++ b/plugins/transfer_pokemon/__init__.py
@@ -31,7 +31,7 @@ def get_indexed_pokemon(bot, transfer_list=None):
 
 # Filters Pokemon deployed at gyms
 # Never disable as it might lead to a ban!
-@manager.on("pokemon_bag_full", priority=-40)
+@manager.on("pokemon_bag_full", priority=-50)
 def filter_deployed_pokemon(bot, transfer_list=None, filter_list=None):
     # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]
 
@@ -50,7 +50,7 @@ def filter_deployed_pokemon(bot, transfer_list=None, filter_list=None):
 
 # Filters favorited Pokemon
 # Never disable as it might lead to a ban!
-@manager.on("pokemon_bag_full", priority=-30)
+@manager.on("pokemon_bag_full", priority=-40)
 def filter_favorited_pokemon(bot, transfer_list=None, filter_list=None):
     # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]
 
@@ -65,6 +65,19 @@ def filter_favorited_pokemon(bot, transfer_list=None, filter_list=None):
         filter_list.append("excluding favorited Pokemon")
 
     return {"transfer_list": new_transfer_list, "filter_list": filter_list}
+
+
+# Wraps a caught Pokemon into a list for transferring
+@manager.on("pokemon_caught", priority=-30)
+def wrap_pokemon_in_list(transfer_list=None, pokemon=None):
+    if pokemon is None:
+        return
+
+    if transfer_list is None:
+        transfer_list = []
+
+    transfer_list.append(pokemon)
+    return {"transfer_list": transfer_list}
 
 
 # Filters Pokemon based on ignore/always keep list
@@ -92,13 +105,14 @@ def filter_pokemon_by_ignore_list(bot, transfer_list=None, filter_list=None):
     if len(new_transfer_list) != len(transfer_list):
         if len(excluded_species) > 1:
             excluded_species_list = list(excluded_species)
-            filter_list.append("excluding " + "s, ".join(excluded_species_list[:-1]) + " and " + excluded_species_list[-1] + "s")
+            filter_list.append("excluding " + "s, ".join(excluded_species_list[:-1]) + "s and " + excluded_species_list[-1] + "s")
         else:
             filter_list.append("excluding " + excluded_species.pop() + "s")
 
-    return {"transfer_list": transfer_list, "filter_list": filter_list}
+    return {"transfer_list": new_transfer_list, "filter_list": filter_list}
 
 
+# TODO: Fix this function to use dependency injection for release rules
 @manager.on("pokemon_bag_full", "pokemon_caught", priority=-10)
 def filter_pokemon_by_cp_iv(bot, transfer_list=None, filter_list=None):
     # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]

--- a/plugins/transfer_pokemon/__init__.py
+++ b/plugins/transfer_pokemon/__init__.py
@@ -5,120 +5,194 @@ from pokemongo_bot import logger
 from plugins.transfer_pokemon.config import release_rules
 
 
-@manager.on("pokemon_bag_full", "pokemon_caught", priority=1000)
-def filter_pokemon(bot, transfer_list=None, pokemon=None):
-    # type: (PokemonGoBot, Optional[List[Pokemon]], Pokemon) -> Dict[Str, List[Pokemon]]
+def get_transfer_list(bot, transfer_list=None):
+    if transfer_list is None:
+        bot.api_wrapper.get_player().get_inventory()
+        response_dict = bot.api_wrapper.call()
+        transfer_list = response_dict['pokemon']
+
+    return None if len(transfer_list) == 0 else transfer_list
+
+
+def get_indexed_pokemon(bot, transfer_list=None):
+    transfer_list = get_transfer_list(bot, transfer_list)
+    if transfer_list is None:
+        return None
+
+    indexed_pokemon = dict()
+    for deck_pokemon in transfer_list:
+        pokemon_num = deck_pokemon.pokemon_id
+        if pokemon_num not in indexed_pokemon:
+            indexed_pokemon[pokemon_num] = list()
+        indexed_pokemon[pokemon_num].append(deck_pokemon)
+
+    return indexed_pokemon
+
+
+# Filters Pokemon deployed at gyms
+# Never disable as it might lead to a ban!
+@manager.on("pokemon_bag_full", priority=-40)
+def filter_deployed_pokemon(bot, transfer_list=None, filter_list=None):
+    # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]
+
+    filter_list = [] if filter_list is None else filter_list
+    transfer_list = get_transfer_list(bot, transfer_list)
+    if transfer_list is None:
+        return False
+
+    new_transfer_list = [deck_pokemon for deck_pokemon in transfer_list if deck_pokemon.deployed_fort_id is None]
+
+    if len(new_transfer_list) != len(transfer_list):
+        filter_list.append("excluding Pokemon at gyms")
+
+    return {"transfer_list": new_transfer_list, "filter_list": filter_list}
+
+
+# Filters favorited Pokemon
+# Never disable as it might lead to a ban!
+@manager.on("pokemon_bag_full", priority=-30)
+def filter_favorited_pokemon(bot, transfer_list=None, filter_list=None):
+    # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]
+
+    filter_list = [] if filter_list is None else filter_list
+    transfer_list = get_transfer_list(bot, transfer_list)
+    if transfer_list is None:
+        return False
+
+    new_transfer_list = [deck_pokemon for deck_pokemon in transfer_list if deck_pokemon.favorite is False]
+
+    if len(new_transfer_list) != len(transfer_list):
+        filter_list.append("excluding favorited Pokemon")
+
+    return {"transfer_list": new_transfer_list, "filter_list": filter_list}
+
+
+# Filters Pokemon based on ignore/always keep list
+@manager.on("pokemon_bag_full", "pokemon_caught", priority=-20)
+def filter_pokemon_by_ignore_list(bot, transfer_list=None, filter_list=None):
+    # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]
+
+    filter_list = [] if filter_list is None else filter_list
+    transfer_list = get_transfer_list(bot, transfer_list)
+    if transfer_list is None:
+        return False
+
+    ignore_list = bot.config.ign_init_trans.split(',')
+
+    new_transfer_list = []
+    excluded_species = set()
+    for pokemon in transfer_list:
+        species_num = pokemon.pokemon_id
+        species_name = bot.pokemon_list[species_num - 1]["Name"]
+        if str(species_num) not in ignore_list and species_name not in ignore_list:
+            new_transfer_list.append(pokemon)
+        else:
+            excluded_species.add(species_name)
+
+    if len(new_transfer_list) != len(transfer_list):
+        if len(excluded_species) > 1:
+            excluded_species_list = list(excluded_species)
+            filter_list.append("excluding " + "s, ".join(excluded_species_list[:-1]) + " and " + excluded_species_list[-1] + "s")
+        else:
+            filter_list.append("excluding " + excluded_species.pop() + "s")
+
+    return {"transfer_list": transfer_list, "filter_list": filter_list}
+
+
+@manager.on("pokemon_bag_full", "pokemon_caught", priority=-10)
+def filter_pokemon_by_cp_iv(bot, transfer_list=None, filter_list=None):
+    # type: (PokemonGoBot, Optional[List[Pokemon]]), Optional[List[str]] -> Dict[Str, List]
+
+    filter_list = [] if filter_list is None else filter_list
+    transfer_list = get_transfer_list(bot, transfer_list)
+    if transfer_list is None:
+        return False
+
     default_rules = {
         'release_below_cp': bot.config.cp,
         'release_below_iv': bot.config.pokemon_potential,
         'logic': 'and',
     }
 
-    def log(text, color="black"):
-        logger.log(text, color=color, prefix="Transfer")
+    indexed_pokemon = get_indexed_pokemon(bot, transfer_list)
 
-    if transfer_list is None:
-        bot.api_wrapper.get_player().get_inventory()
-        response_dict = bot.api_wrapper.call()
-        transfer_list = response_dict['pokemon']
+    if release_rules:
+        filter_list.append("according to per-species CP/IV rules")
+    else:
+        filter_list.append("with CP <= {} and IV <= {}".format(bot.config.cp, bot.config.pokemon_potential))
 
-    new_transfer_list = []
-    indexed_pokemon = dict()
-    for deck_pokemon in transfer_list:
+    pokemon_groups = list(indexed_pokemon.keys())
+    for pokemon_group in pokemon_groups:
 
-        # ignore deployed pokemon
-        if deck_pokemon.deployed_fort_id is not None:
+        # skip if it's our only pokemon of this type
+        if len(indexed_pokemon[pokemon_group]) < 2:
+            del indexed_pokemon[pokemon_group]
             continue
 
-        pokemon_num = deck_pokemon.pokemon_id
-        if pokemon_num not in indexed_pokemon:
-            indexed_pokemon[pokemon_num] = list()
-        indexed_pokemon[pokemon_num].append(deck_pokemon)
+        # Load rules for this group. If rule doesnt exist make one with default settings.
+        pokemon_name = bot.pokemon_list[pokemon_group - 1]["Name"]
+        pokemon_rules = release_rules.get(pokemon_name, default_rules)
+        cp_threshold = pokemon_rules.get('release_below_cp', bot.config.cp)
+        iv_threshold = pokemon_rules.get('release_below_iv', bot.config.pokemon_potential)
+        rules_logic = pokemon_rules.get('logic', 'and')
 
-    if bot.config.cp or bot.config.pokemon_potential:
-        ignore_list = bot.config.ign_init_trans.split(',')
-        if release_rules:
-            log(
-                "Transferring {} Pokemon according to rules, excluding [{}].".format(
-                    ("caught" if isinstance(pokemon, Pokemon) else "all"),
-                    ', '.join(ignore_list)
-                )
-            )
+        # only keep everything below specified CP
+        group_transfer_list = []
+        for deck_pokemon in indexed_pokemon[pokemon_group]:
+
+            # is the Pokemon's CP less than our set threshold?
+            within_cp = (deck_pokemon.combat_power <= cp_threshold)
+
+            # is the Pokemon's IV less than our set threshold?
+            within_potential = (deck_pokemon.potential <= iv_threshold)
+
+            # if we are using AND logic and both are true, transfer
+            if rules_logic == 'and' and (within_cp and within_potential):
+                group_transfer_list.append(deck_pokemon)
+
+            # if we are using OR logic and either is true, transfer
+            elif rules_logic == 'or' and (within_cp or within_potential):
+                group_transfer_list.append(deck_pokemon)
+
+        # Check if we are trying to remove all the pokemon in this group.
+        if len(group_transfer_list) == len(indexed_pokemon[pokemon_group]):
+            # Sort by CP * potential and keep the best one
+            indexed_pokemon[pokemon_group].sort(key=lambda p: p.combat_power * p.potential)
+            indexed_pokemon[pokemon_group] = indexed_pokemon[pokemon_group][:-1]
         else:
-            log(
-                "Transferring {} Pokemon that have CP <= {} and IV <= {}, excluding [{}].".format(
-                    ("caught" if isinstance(pokemon, Pokemon) else "all"),
-                    bot.config.cp,
-                    bot.config.pokemon_potential,
-                    ', '.join(ignore_list)
-                )
-            )
+            indexed_pokemon[pokemon_group] = group_transfer_list
 
-        groups = list(indexed_pokemon.keys())
-        for group in groups:
-            # Load rules for this group. If rule doesnt exist make one with default settings.
-            pokemon_name = bot.pokemon_list[group - 1]["Name"]
-            pokemon_rules = release_rules.get(pokemon_name, default_rules)
-            cp_threshold = pokemon_rules.get('release_below_cp', bot.config.cp)
-            iv_threshold = pokemon_rules.get('release_below_iv', bot.config.pokemon_potential)
-            rules_logic = pokemon_rules.get('logic', 'and')
+    new_transfer_list = []
+    pokemon_groups = list(indexed_pokemon.keys())
+    for pokemon_group in pokemon_groups:
+        for deck_pokemon in indexed_pokemon[pokemon_group]:
+            new_transfer_list.append(deck_pokemon)
 
-            # If we've been given a caught pokemon, only process that group
-            if isinstance(pokemon, Pokemon) and group != pokemon.pokemon_id:
-                del indexed_pokemon[group]
-                continue
-
-            # check if ID or species name is in ignore list or if it's our only pokemon of this type
-            if str(group) in ignore_list or bot.pokemon_list[group - 1]["Name"] in ignore_list or len(indexed_pokemon[group]) < 2:
-                del indexed_pokemon[group]
-            else:
-                # only keep everything below specified CP
-                group_transfer_list = []
-                for deck_pokemon in indexed_pokemon[group]:
-                    within_cp = (deck_pokemon.combat_power <= cp_threshold)
-                    within_potential = (deck_pokemon.potential <= iv_threshold)
-                    if rules_logic == 'and' and (within_cp and within_potential):
-                        continue
-                    elif rules_logic == 'or' and (within_cp or within_potential):
-                        continue
-                    group_transfer_list.append(deck_pokemon)
-
-                # Check if we are trying to remove all the pokemon in this group.
-                if len(group_transfer_list) == len(indexed_pokemon[group]):
-                    # Sort by CP * potential and keep the best one
-                    indexed_pokemon[group].sort(key=lambda p: p.combat_power * p.potential)
-                    indexed_pokemon[group] = indexed_pokemon[group][:-1]
-                else:
-                    indexed_pokemon[group] = group_transfer_list
-
-        for group in indexed_pokemon:
-            for deck_pokemon in indexed_pokemon[group]:
-                new_transfer_list.append(deck_pokemon)
-
-    else:
-        log("Transferring all duplicate Pokemon, keeping the highest CP for each.")
-
-        for group in indexed_pokemon:
-            # There's only one, keep it
-            if str(group) in ignore_list or bot.pokemon_list[group - 1]["Name"] in ignore_list or len(indexed_pokemon[group]) < 2:
-                continue
-
-            # Sort by CP and keep the best one
-            indexed_pokemon[group].sort(key=lambda current_pokemon: current_pokemon.combat_power)
-            new_transfer_list += indexed_pokemon[group][:-1]
-
-    return {"transfer_list": new_transfer_list}
+    return {"transfer_list": new_transfer_list, "filter_list": filter_list}
 
 
-@manager.on("pokemon_bag_full", "transfer_pokemon", "pokemon_caught", priority=1000)
-def transfer_pokemon(bot, transfer_list=None):
-    # type: (PokemonGoBot, Optional[List[Pokemon]]) -> None
+@manager.on("pokemon_bag_full", "transfer_pokemon", "pokemon_caught", priority=0)
+def transfer_pokemon(bot, transfer_list=None, filter_list=None):
+    # type: (PokemonGoBot, Optional[List[Pokemon]], Optional[List[str]]) -> None
+
+    filter_list = [] if filter_list is None else filter_list
 
     def log(text, color="black"):
         logger.log(text, color=color, prefix="Transfer")
 
     if transfer_list is None or len(transfer_list) == 0:
-        log("No Pokemon to transfer.", color="yellow")
+        return False
+
+    output_str = "Transferring {} Pokemon".format(len(transfer_list))
+
+    # Print out the list of filters used
+    filter_list = filter_list[::-1]
+    if len(filter_list) > 1:
+        output_str += " " + ", ".join(filter_list[:-1]) + " and " + filter_list[-1]
+    elif len(filter_list) == 1:
+        output_str += " " + filter_list[0]
+
+    log(output_str)
 
     for index, pokemon in enumerate(transfer_list):
         pokemon_num = pokemon.pokemon_id

--- a/pokemongo_bot/tests/plugins/transfer_pokemon_test.py
+++ b/pokemongo_bot/tests/plugins/transfer_pokemon_test.py
@@ -1,0 +1,121 @@
+import unittest
+
+from api.pokemon import Pokemon
+from plugins.transfer_pokemon import filter_deployed_pokemon, filter_favorited_pokemon, filter_pokemon_by_cp_iv, filter_pokemon_by_ignore_list, transfer_pokemon, wrap_pokemon_in_list
+from pokemongo_bot.tests import create_mock_bot
+
+
+class TransferPokemonPluginTest(unittest.TestCase):
+
+    def test_wrap_pokemon(self):
+        transfer_list = [self._create_pokemon(unique_id=1)]
+        transfer_list = wrap_pokemon_in_list(transfer_list=transfer_list, pokemon=self._create_pokemon(unique_id=2))["transfer_list"]
+        assert len(transfer_list) == 2
+        assert transfer_list[0].unique_id == 1
+        assert transfer_list[1].unique_id == 2
+
+    def test_deployed_pokemon_filter(self):
+        bot = create_mock_bot()
+
+        transfer_list = [self._create_pokemon(unique_id=1, deployed=True),
+                         self._create_pokemon(unique_id=2, deployed=True),
+                         self._create_pokemon(unique_id=3, deployed=True),
+                         self._create_pokemon(unique_id=4, deployed=False),
+                         self._create_pokemon(unique_id=5, deployed=True),
+                         self._create_pokemon(unique_id=6, deployed=False)]
+
+        result_dict = filter_deployed_pokemon(bot=bot, transfer_list=transfer_list)
+        filtered_list = result_dict["transfer_list"]
+        assert len(filtered_list) == 2
+        assert filtered_list[0].unique_id == 4
+        assert filtered_list[1].unique_id == 6
+        assert result_dict["filter_list"][0] == "excluding Pokemon at gyms"
+
+        transfer_list = [self._create_pokemon(deployed=False)]
+        result_dict = filter_deployed_pokemon(bot=bot, transfer_list=transfer_list)
+        assert len(result_dict["transfer_list"]) == 1
+        assert len(result_dict["filter_list"]) == 0
+
+        self.set_empty_inventory(bot)
+        assert filter_deployed_pokemon(bot=bot) is False
+
+    def test_favorited_pokemon_filter(self):
+        bot = create_mock_bot()
+
+        transfer_list = [self._create_pokemon(unique_id=1, favorite=True),
+                         self._create_pokemon(unique_id=2, favorite=True),
+                         self._create_pokemon(unique_id=3, favorite=True),
+                         self._create_pokemon(unique_id=4, favorite=False),
+                         self._create_pokemon(unique_id=5, favorite=True),
+                         self._create_pokemon(unique_id=6, favorite=False)]
+
+        result_dict = filter_favorited_pokemon(bot=bot, transfer_list=transfer_list)
+        filtered_list = result_dict["transfer_list"]
+        assert len(filtered_list) == 2
+        assert filtered_list[0].unique_id == 4
+        assert filtered_list[1].unique_id == 6
+        assert result_dict["filter_list"][0] == "excluding favorited Pokemon"
+
+        transfer_list = [self._create_pokemon(favorite=False)]
+        result_dict = filter_favorited_pokemon(bot=bot, transfer_list=transfer_list)
+        assert len(result_dict["transfer_list"]) == 1
+        assert len(result_dict["filter_list"]) == 0
+
+        self.set_empty_inventory(bot)
+        assert filter_favorited_pokemon(bot=bot) is False
+
+    def test_ignore_list_filter(self):
+        bot = create_mock_bot({
+            "ign_init_trans": "1,Ivysaur,3,Mewtwo"
+        })
+
+        transfer_list = [self._create_pokemon(unique_id=1, species_id=1),
+                         self._create_pokemon(unique_id=2, species_id=5),
+                         self._create_pokemon(unique_id=3, species_id=2),
+                         self._create_pokemon(unique_id=4, species_id=4),
+                         self._create_pokemon(unique_id=5, species_id=3),
+                         self._create_pokemon(unique_id=6, species_id=1),
+                         self._create_pokemon(unique_id=7, species_id=5)]
+
+        result_dict = filter_pokemon_by_ignore_list(bot=bot, transfer_list=transfer_list)
+        filtered_list = result_dict["transfer_list"]
+        assert len(filtered_list) == 3
+        assert filtered_list[0].unique_id == 2
+        assert filtered_list[1].unique_id == 4
+        assert filtered_list[2].unique_id == 7
+        assert "Bulbasaurs" in result_dict["filter_list"][0]
+        assert "Ivysaurs" in result_dict["filter_list"][0]
+        assert "Venusaurs" in result_dict["filter_list"][0]
+
+        transfer_list = [self._create_pokemon(species_id=42)]
+        result_dict = filter_pokemon_by_ignore_list(bot=bot, transfer_list=transfer_list)
+        assert len(result_dict["transfer_list"]) == 1
+        assert len(result_dict["filter_list"]) == 0
+
+        transfer_list = [self._create_pokemon(species_id=1)]
+        result_dict = filter_pokemon_by_ignore_list(bot=bot, transfer_list=transfer_list)
+        assert len(result_dict["transfer_list"]) == 0
+        assert result_dict["filter_list"][0] == "excluding Bulbasaurs"
+
+        self.set_empty_inventory(bot)
+        assert filter_pokemon_by_ignore_list(bot=bot) is False
+
+    @staticmethod
+    def _create_pokemon(unique_id=0, species_id=1, cp=1.0, iv=1.0, favorite=False, deployed=False):
+        return Pokemon({
+            "id": unique_id,
+            "pokemon_id": species_id,
+            "cp": cp,
+            "individual_attack": int(15 * iv),
+            "individual_defense": int(15 * iv),
+            "individual_stamina": int(15 * iv),
+            "favorite": 1 if favorite else 0,
+            "deployed_fort_id": "123456" if deployed else None
+        })
+
+    @staticmethod
+    def set_empty_inventory(bot):
+        pgo = bot.api_wrapper._api  # pylint: disable=protected-access
+
+        pgo.set_response("get_player", {})
+        pgo.set_response("get_inventory", {})


### PR DESCRIPTION
### Short Description:

The fix in #298 was backwards. This should properly fix it. To clear up confusion, we no longer skip a loop iteration but instead just add a Pokemon to the list if a condition is met.
### Changes:
- Moved individual filters into separate functions instead of putting them all in one function.
- Fixed logic from #298.
- Add unit tests for the refactored filters.

Closes #301.

@OpenPoGo/maintainers
