### PR TITLE
Allow (un)favorite pokemon

### DIFF
--- a/api/pokemon.py
+++ b/api/pokemon.py
@@ -36,4 +36,7 @@ class Pokemon(JSONEncodable):
         self.height = data.get("height_m", 0.0)
         self.weight = data.get("weight_kg", 0.0)
 
+        self.favorite = data.get("favorite", 0) == 1
+        self.nickname = data.get("nickname", None)
+
         self.deployed_fort_id = data.get("deployed_fort_id", None)

--- a/api/state_manager.py
+++ b/api/state_manager.py
@@ -29,7 +29,8 @@ class StateManager(object):
             "USE_ITEM_EGG_INCUBATOR": self._parse_use_incubator,
             "GET_HATCHED_EGGS": self._parse_get_hatched_eggs,
             "EVOLVE_POKEMON": self._parse_evolution,
-            "DOWNLOAD_ITEM_TEMPLATES": self._identity
+            "DOWNLOAD_ITEM_TEMPLATES": self._identity,
+            "SET_FAVORITE_POKEMON": self._identity
         }
 
         # Maps methods to the state objects that they refresh.
@@ -49,7 +50,8 @@ class StateManager(object):
             "FORT_SEARCH": ["FORT_SEARCH"],
             "RECYCLE_INVENTORY_ITEM": [],
             "EVOLVE_POKEMON": ["evolution"],
-            "DOWNLOAD_ITEM_TEMPLATES": ["DOWNLOAD_ITEM_TEMPLATES"]
+            "DOWNLOAD_ITEM_TEMPLATES": ["DOWNLOAD_ITEM_TEMPLATES"],
+            "SET_FAVORITE_POKEMON": ["SET_FAVORITE_POKEMON"]
         }
 
         # Maps methods to the state objects that they invalidate.
@@ -73,7 +75,8 @@ class StateManager(object):
             "FORT_SEARCH": ["player", "inventory", "eggs"],
             "RECYCLE_INVENTORY_ITEM": ["inventory"],
             "EVOLVE_POKEMON": ["player", "inventory", "pokemon", "pokedex", "candy"],
-            "DOWNLOAD_ITEM_TEMPLATES": []
+            "DOWNLOAD_ITEM_TEMPLATES": [],
+            "SET_FAVORITE_POKEMON": ["pokemon"]
         }
 
         self.current_state = {}

--- a/plugins/socket/uievents.py
+++ b/plugins/socket/uievents.py
@@ -167,4 +167,4 @@ def register_ui_events(socketio, state):
             pkm_id = int(evt["id"])
             favorite = evt["favorite"]
 
-            result = bot.api_wrapper.set_favorite_pokemon(pokemon_id=pkm_id, is_favorite=favorite).call()
+            bot.api_wrapper.set_favorite_pokemon(pokemon_id=pkm_id, is_favorite=favorite).call()

--- a/plugins/socket/uievents.py
+++ b/plugins/socket/uievents.py
@@ -157,3 +157,14 @@ def register_ui_events(socketio, state):
             item_name = bot.item_list[item_id]
             log("Recycling {} {}{}".format(count, item_name, "s" if count > 1 else ""))
             bot.api_wrapper.recycle_inventory_item(item_id=item_id, count=count).call()
+
+    @socketio.on("favorite_pokemon", namespace="/event")
+    def client_ask_for_favorite_pokemon(evt):
+        if "bot" in state:
+            logger.log("Web UI action: Favorite", "yellow", fire_event=False)
+
+            bot = state["bot"]
+            pkm_id = int(evt["id"])
+            favorite = evt["favorite"]
+
+            result = bot.api_wrapper.set_favorite_pokemon(pokemon_id=pkm_id, is_favorite=favorite).call()


### PR DESCRIPTION
### Short Description:

Can (un)favorite from the UI
This will allow the transfer plugin to newver transfer pokemon.

@OpenPoGo/maintainers
