### PR TITLE
fixes OBOE, fixes #317

### DIFF
--- a/pokecli.py
+++ b/pokecli.py
@@ -51,7 +51,7 @@ def init_config():
             print("Command line arguments are deprecated. See README for details.")
             print("Usage: pokecli.py [path to config.yml]")
             exit(1)
-        config_path = sys.argv[2]
+        config_path = sys.argv[1]
 
     if not os.path.isfile(config_path):
         print("{} does not exist.".format(config_path))


### PR DESCRIPTION
### Short Description:

see #317 
### Changes:

changes line 51 to fix off-by-one-error and make loading of configuration by parameter possible again
see #317

@OpenPoGo/maintainers
