### PR TITLE
Use pgoapi cell fetcher

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -37,6 +37,10 @@ mapping:
     # Specify what units for distance the bot should use
     distance_unit: "km"
 
+    # The radius (in meters) to fetch cell data for. Cell data includes pokestops and nearby pokemon
+    # Max value is 1500
+    cell_radius: 500
+
 movement:
     # Use Google Maps Direction API (google) or just walk directly (direct)
     path_finder: "google"

--- a/pokemongo_bot/tests/mapper_test.py
+++ b/pokemongo_bot/tests/mapper_test.py
@@ -5,6 +5,7 @@ import unittest
 from googlemaps import Client
 from googlemaps.exceptions import ApiError
 from mock import Mock
+from mock import call
 
 from pokemongo_bot.mapper import Mapper
 from pokemongo_bot.tests import create_core_test_config, create_mock_api_wrapper, test_account_name
@@ -27,9 +28,13 @@ class MapperTest(unittest.TestCase):
     def test_get_cells(self):
         account = test_account_name()
         config = create_core_test_config({
+            "debug": True,
             "login": {
                 "username": account,
             },
+            "mapping": {
+                "cell_radius": 500
+            }
         })
         api_wrapper = create_mock_api_wrapper(config)
         google_maps = Mock(spec=Client)
@@ -72,6 +77,9 @@ class MapperTest(unittest.TestCase):
         config = create_core_test_config({
             "login": {
                 "username": account
+            },
+            "mapping": {
+                "cell_radius": 500
             }
         })
         api_wrapper = create_mock_api_wrapper(config)


### PR DESCRIPTION
### Short Description:

Use pgoapi `get_cell_ids` function to get a list of nearby cells.

Fixes #326
### Changes:
- Use pgoapi `get_cell_ids` function to get a list of nearby cells.
- Added debug output for cell coordinates

@OpenPoGo/maintainers
