### PR TITLE
Do not sleep on heartbeat

### DIFF
--- a/app/kernel.py
+++ b/app/kernel.py
@@ -50,8 +50,8 @@ class Kernel(object):
         self._disabled_plugins.append(plugin_name)
 
     def boot(self):
-        self.load_config()
         # type: () -> None
+        self.load_config()
         self._plugin_manager = PluginManager(self._configs['core']['plugins']['include'])
         for plugin in self._plugin_manager.get_available_plugins():
             if plugin not in self._disabled_plugins:

--- a/pokemongo_bot/service/player.py
+++ b/pokemongo_bot/service/player.py
@@ -27,9 +27,11 @@ class Player(object):
         self._logged_in = self._api_wrapper.login()
         return self._logged_in
 
-    def update(self):
+    def update(self, do_sleep=True):
         response_dict = self._api_wrapper.get_player().get_inventory().call()
-        sleep(2)
+
+        if do_sleep:
+            sleep(2)
 
         if response_dict is None:
             self._log('Failed to retrieve player and inventory stats', color='red')
@@ -113,7 +115,7 @@ class Player(object):
         self._api_wrapper.get_hatched_eggs()
         self._api_wrapper.check_awarded_badges()
 
-        self.update()
+        self.update(do_sleep=False)
 
         if len(self._player.hatched_eggs):
             self._player.hatched_eggs.pop(0)


### PR DESCRIPTION
### Short Description:

The bot is really slow at moving as there is a 1 sec sleep every step, +2-3 secs sleep every step for the heartbeat. This removes the sleep on the heartbeat as a quick win fix until a solution can be found from #312
### Changes:
- Do not sleep on heartbeat

@OpenPoGo/maintainers
