### PR TITLE
Use plugins.config value for plugin config file location

### DIFF
--- a/app/kernel.py
+++ b/app/kernel.py
@@ -36,7 +36,7 @@ class Kernel(object):
 
         config_dir = os.path.dirname(self._config_file)
         for node in os.listdir(os.path.join(config_dir, 'plugins')):
-            location = os.path.join(config_dir, 'plugins', node)
+            location = os.path.join(config_dir, self._configs['core']['plugins']['config'], node)
             if os.path.isfile(location) and node[-4:].lower() == '.yml':
                 with open(location, 'r') as config_file:
                     module_name = node[:-4]

--- a/app/kernel.py
+++ b/app/kernel.py
@@ -35,12 +35,13 @@ class Kernel(object):
             self.disable_plugin(plugin)
 
         config_dir = os.path.dirname(self._config_file)
-        for node in os.listdir(os.path.join(config_dir, 'plugins')):
-            location = os.path.join(config_dir, self._configs['core']['plugins']['config'], node)
-            if os.path.isfile(location) and node[-4:].lower() == '.yml':
-                with open(location, 'r') as config_file:
-                    module_name = node[:-4]
-                    self._configs[module_name] = ruamel.yaml.load(config_file.read(), ruamel.yaml.RoundTripLoader)
+        for plugin_config_dir in self._configs['core']['plugins']['config']:
+            for node in os.listdir(os.path.join(config_dir, plugin_config_dir)):
+                location = os.path.join(config_dir, plugin_config_dir, node)
+                if os.path.isfile(location) and node[-4:].lower() == '.yml':
+                    with open(location, 'r') as config_file:
+                        module_name = node[:-4]
+                        self._configs[module_name] = ruamel.yaml.load(config_file.read(), ruamel.yaml.RoundTripLoader)
 
     def get_config(self):
         return self._configs

--- a/app/tests/config/config.yml
+++ b/app/tests/config/config.yml
@@ -66,4 +66,5 @@ plugins:
         - ./app/tests/plugins
 
     # Load plugin YAML config files from this folder
-    config: "config/plugins"
+    config:
+        - "plugins"

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -69,4 +69,5 @@ plugins:
         - ./plugins
 
     # Load plugin YAML config files from this folder, relative to the main config file directory
-    config: "plugins"
+    config:
+        - "plugins"

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -68,6 +68,7 @@ plugins:
     include:
         - ./plugins
 
-    # Load plugin YAML config files from this folder, relative to the main config file directory
+    # Load plugin YAML config files from these directories, relative to the main config file directory.
+    # Later directories will override configs in previous directories.
     config:
         - "plugins"

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -68,5 +68,5 @@ plugins:
     include:
         - ./plugins
 
-    # Load plugin YAML config files from this folder
-    config: "config/plugins"
+    # Load plugin YAML config files from this folder, relative to the main config file directory
+    config: "plugins"


### PR DESCRIPTION
### Short Description:

Fixes the kernel not respecting the `plugins.config` value to find the plugin config locations

**THIS WILL BREAK CURRENT CHECKOUTS**
### Changes:
- kernel now reads `plugins.config`

@OpenPoGo/maintainers
