### PR TITLE
fix event name for consistency

### DIFF
--- a/plugins/socket/botevents.py
+++ b/plugins/socket/botevents.py
@@ -118,4 +118,4 @@ class BotEvents(object):
             self.socketio.emit("route", route, namespace="/event")
 
     def manual_destination_reached_event(self, bot=None):
-        self.socketio.emit("manual_destination_reached_event")
+        self.socketio.emit("manual_destination_reached")


### PR DESCRIPTION
### Short Description:

fix event name for consistency
### Changes:
- event name for manual destination

@OpenPoGo/maintainers
